### PR TITLE
(SIMP-392) Added sssd::install::client

### DIFF
--- a/build/pupmod-sssd.spec
+++ b/build/pupmod-sssd.spec
@@ -1,7 +1,7 @@
 Summary: SSSD Puppet Module
 Name: pupmod-sssd
 Version: 4.1.0
-Release: 7
+Release: 8
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -14,9 +14,9 @@ Requires: puppet >= 3.3.0
 Requires: simp_bootstrap >= 4.1.0-2
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
-Obsoletes: pupmod-sssd-test
+Obsoletes: pupmod-sssd-test >= 0.0.1
 
-Prefix: /etc/puppet/environments/simp/modules
+Prefix: %{_sysconfdir}/puppet/environments/simp/modules
 
 %description
 This Puppet module manages the configuration of the System Security Services
@@ -59,6 +59,10 @@ fi
 # Post uninitall stuff
 
 %changelog
+* Thu Dec 24 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-8
+- Added an sssd::install::client class for installing only the client
+  libraries.
+
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-7
 - migration to simplib and simpcat (lib/ only)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,6 +17,7 @@
 class sssd::install (
   $install_user_tools = true
 ) {
+  contain '::sssd::install::client'
 
   validate_bool($install_user_tools)
 

--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -1,0 +1,9 @@
+# == Class: sssd::install::client
+#
+# Install the sssd-client package
+#
+class sssd::install::client (
+  $ensure = 'latest'
+){
+  package { 'sssd-client': ensure => $ensure }
+}

--- a/templates/provider/ldap.erb
+++ b/templates/provider/ldap.erb
@@ -153,7 +153,7 @@
   }
 
   _output = []
-  _string_params.each do |param|
+  _string_params.sort.each do |param|
     value = eval(%(@#{param}))
 
     unless value.to_s.empty?
@@ -161,7 +161,7 @@
     end
   end
 
-  _array_params.keys.each do |param|
+  _array_params.keys.sort.each do |param|
     value = eval(%(@#{param}))
 
     if value && !value.empty?


### PR DESCRIPTION
In some cases, you need the SSSD libraries to be installed regardless as
to whether or not you are running the SSSD daemon.

This patch provides that ability and enables it by default if you
include '::sssd'.

SIMP-392 #comment Corrected issues found during testing