### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,17 +1,18 @@
 ---
 fixtures:
   repositories:
-    auditd: "git://github.com/simp/pupmod-simp-auditd"
-    augeasproviders_core: "git://github.com/simp/augeasproviders_core"
-    augeasproviders_grub: "git://github.com/simp/augeasproviders_grub"
-    concat: "git://github.com/simp/pupmod-simp-concat"
-    nscd: "git://github.com/simp/pupmod-simp-nscd"
-    openldap: "git://github.com/simp/pupmod-simp-openldap"
-    pki: "git://github.com/simp/pupmod-simp-pki"
-    simplib: "git://github.com/simp/pupmod-simp-simplib"
-    stdlib: "git://github.com/simp/puppetlabs-stdlib"
+    auditd: "https://github.com/simp/pupmod-simp-auditd.git"
+    augeasproviders_core: "https://github.com/simp/augeasproviders_core.git"
+    augeasproviders_grub: "https://github.com/simp/augeasproviders_grub.git"
+    simpcat: "https://github.com/simp/pupmod-simp-concat.git"
+    compliance: "https://github.com/trevor-vaughan/pupmod-compliance.git"
+    nscd: "https://github.com/simp/pupmod-simp-nscd.git"
+    openldap: "https://github.com/simp/pupmod-simp-openldap.git"
+    pki: "https://github.com/simp/pupmod-simp-pki.git"
+    simplib: "https://github.com/simp/pupmod-simp-simplib.git"
+    stdlib: "https://github.com/simp/puppetlabs-stdlib.git"
     # For acceptance testing
-    simp: "git://github.com/simp/pupmod-simp-simp"
-    tcpwrappers: "git://github.com/simp/pupmod-simp-tcpwrappers"
+    simp: "https://github.com/simp/pupmod-simp-simp.git"
+    tcpwrappers: "https://github.com/simp/pupmod-simp-tcpwrappers.git"
   symlinks:
     sssd: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.*.sw?
+.yardoc
+dist
+/pkg
+/spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+/.rspec_system
+/.vagrant
+/.bundle
+/Gemfile.lock
+/vendor
+/junit
+/log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,6 +1,5 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
---no-variables_not_enclosed-check
 --no-class_inherits_from_params_class-check
 --no-80chars-check
 --no-quoted_booleans-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
+before_script:
+  - bundle
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
+script:
+  - bundle exec rake test
+notifications:
+  email: false
 rvm:
-#  - 1.8.7  # bombs out on mime-types
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
-script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
-# NOTE: `:environmentpath` was not supported before Puppet 3.5
 env:
   global:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
     - PUPPET_VERSION="~> 3.7.0"
     - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
     - PUPPET_VERSION="~> 3.8.0"
@@ -26,30 +31,60 @@ env:
     - PUPPET_VERSION="~> 4.0.0"
     - PUPPET_VERSION="~> 4.1.0"
     - PUPPET_VERSION="~> 4.2.0"
-
 matrix:
   fast_finish: true
   allow_failures:
     - rvm: 1.8.7
     - rvm: 2.1.0
     - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
     - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
     - env: PUPPET_VERSION="~> 4.1.0"
     - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
 
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
 
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
@@ -15,8 +15,9 @@ group :test do
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts"
-  # A bug the broke .ignore_paths was fixed on 30 Oct 2015:
-  gem "puppet-lint", :git => 'https://github.com/rodjek/puppet-lint.git'
+
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
@@ -40,7 +41,11 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'


### PR DESCRIPTION
This commit synchronizes all common static module assets with current
SIMP module standards.

Also:
- created .gitignore

SIMP-667 #comment updated `pupmod-simp-sssd`
SIMP-756 #close #comment normalized common module assets