### PR TITLE
(SIMP-917) Fix bug in SSSD LDAP Provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,25 +35,16 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: 1.8.7
-    - rvm: 2.1.0
     - rvm: 2.2.1
     - env: PUPPET_VERSION="~> 3.5.0"
     - env: PUPPET_VERSION="~> 3.6.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
-    - env: PUPPET_VERSION="~> 4.0.0"
-    - env: PUPPET_VERSION="~> 4.1.0"
-    - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.2.0"
+    env: PUPPET_VERSION="~> 4.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
@@ -69,22 +60,8 @@ matrix:
 
   # Ruby 2.1.0
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.5.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.6.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.7.0"
+    env: PUPPET_VERSION="< 3.8"
 
   # Ruby 2.2.1
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.5.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.6.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.0"

--- a/build/pupmod-sssd.spec
+++ b/build/pupmod-sssd.spec
@@ -1,7 +1,7 @@
 Summary: SSSD Puppet Module
 Name: pupmod-sssd
-Version: 4.1.0
-Release: 9
+Version: 4.1.1
+Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -10,12 +10,9 @@ Requires: pupmod-auditd >= 4.1.0-3
 Requires: pupmod-common >= 4.2.0-0
 Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-simpcat >= 4.0.0-0
-Requires: puppet >= 3.3.0
-Requires: simp_bootstrap >= 4.1.0-2
-Buildarch: noarch
-Requires: simp-bootstrap >= 4.2.0
-Obsoletes: pupmod-sssd-test >= 0.0.1
 Requires: pupmod-onyxpoint-compliance_markup
+Buildarch: noarch
+Obsoletes: pupmod-sssd-test >= 0.0.1
 
 Prefix: %{_sysconfdir}/puppet/environments/simp/modules
 
@@ -60,6 +57,15 @@ fi
 # Post uninitall stuff
 
 %changelog
+* Mon Mar 14 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.1-0
+- Moved to Semantic Versioning 2.0
+- Fixed a bug in the LDAP provider where we had
+  `ldap_chpass_updates_last_change` as well as
+  `ldap_chpass_update_last_change`. These were consolidated into a correct
+  single `ldap_chpass_update_last_change` Boolean.
+- Removed RPM dependencies on 'simp-boostrap' and 'puppet' since these are
+  technically not necessary for just installing the module.
+
 * Tue Mar 01 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 4.1.0-9
 - Added compliance function support
 

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -31,7 +31,7 @@ define sssd::provider::ldap (
   $ldap_backup_uri = [],
   $ldap_chpass_uri = [],
   $ldap_chpass_backup_uri = [],
-  $ldap_chpass_updates_last_change = true,
+  $ldap_chpass_update_last_change = true,
   $ldap_search_base = hiera('ldap::base_dn'),
   $ldap_schema = 'rfc2307',
   $ldap_default_bind_dn = hiera('ldap::bind_dn'),
@@ -132,7 +132,6 @@ define sssd::provider::ldap (
   $ldap_referrals = '',
   $ldap_dns_service_name = '',
   $ldap_chpass_dns_service_name = '',
-  $ldap_chpass_update_last_change = '',
   $ldap_access_filter = '',
   $ldap_account_expire_policy = 'shadow',
   $ldap_access_order = ['expire','lockout'],
@@ -184,7 +183,6 @@ define sssd::provider::ldap (
   unless empty($ldap_backup_uri) { validate_uri_list($ldap_backup_uri) }
   validate_uri_list($ldap_chpass_uri)
   unless empty($ldap_chpass_backup_uri) { validate_uri_list($ldap_chpass_backup_uri) }
-  validate_bool($ldap_chpass_updates_last_change)
   validate_string($ldap_search_base)
   validate_string($ldap_schema)
   validate_array_member($ldap_schema,['rfc2307','rfc2307bis','IPA','AD'])
@@ -286,7 +284,7 @@ define sssd::provider::ldap (
   unless empty($ldap_referrals) { validate_bool($ldap_referrals) }
   validate_string($ldap_dns_service_name)
   validate_string($ldap_chpass_dns_service_name)
-  unless empty($ldap_chpass_update_last_change) { validate_bool($ldap_chpass_update_last_change) }
+  validate_bool($ldap_chpass_update_last_change)
   validate_string($ldap_access_filter)
   validate_string($ldap_account_expire_policy)
   validate_array_member($ldap_account_expire_policy,['shadow','ad','rhds','ipa','e89ds','nds'])

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-sssd",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author":  "simp",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/templates/provider/ldap.erb
+++ b/templates/provider/ldap.erb
@@ -4,7 +4,6 @@
     'debug_level',
     'debug_timestamps',
     'debug_microseconds',
-    'ldap_chpass_updates_last_change',
     'ldap_search_base',
     'ldap_schema',
     'ldap_default_bind_dn',


### PR DESCRIPTION
The `ldap_chpass_updates_last_change` parameter was incorrect and has
been removed in place of `ldap_chpass_update_last_change`

SIMP-917 #close