### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Mon Aug 01 2016 Nicholas Hughes <nicholasmhughes@gmail.com> - 4.1.3-0
 - Fixed incorrect variable references in ldap.erb.
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Requires: pupmod-simp-auditd >= 4.1.0-3
 Requires: pupmod-simp-compliance_markup
-Requires: pupmod-simp-simpcat >= 4.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Requires: pupmod-simp-simplib >= 1.0.0-0
 Obsoletes: pupmod-sssd-test >= 0.0.1

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -125,7 +125,7 @@ define sssd::domain (
   validate_string($proxy_pam_target)
   validate_string($proxy_lib_name)
 
-  concat_fragment { "sssd+${name}#.domain":
+  simpcat_fragment { "sssd+${name}#.domain":
     content => template('sssd/domain.erb')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class sssd (
     }
   }
 
-  concat_build { 'sssd':
+  simpcat_build { 'sssd':
     order  => ['*.conf', '*.service', '*.domain'],
     target => '/etc/sssd/sssd.conf',
     notify => [
@@ -92,7 +92,7 @@ class sssd (
     ]
   }
 
-  concat_fragment { 'sssd+sssd.conf':
+  simpcat_fragment { 'sssd+sssd.conf':
     content => template('sssd/sssd.conf.erb')
   }
 

--- a/manifests/provider/krb5.pp
+++ b/manifests/provider/krb5.pp
@@ -36,7 +36,7 @@ define sssd::provider::krb5 (
   unless empty($debug_timestamps) { validate_bool($debug_timestamps) }
   unless empty($debug_microseconds) { validate_bool($debug_microseconds) }
 
-  concat_fragment { "sssd+${name}#krb5_provider.domain":
+  simpcat_fragment { "sssd+${name}#krb5_provider.domain":
     content => template('sssd/provider/krb5.erb')
   }
 }

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -358,7 +358,7 @@ define sssd::provider::ldap (
     $_ldap_tls_key = $ldap_tls_key
   }
 
-  concat_fragment { "sssd+${name}#ldap_provider.domain":
+  simpcat_fragment { "sssd+${name}#ldap_provider.domain":
     content => template('sssd/provider/ldap.erb')
   }
 }

--- a/manifests/provider/local.pp
+++ b/manifests/provider/local.pp
@@ -31,7 +31,7 @@ define sssd::provider::local (
   unless empty($debug_timestamps) { validate_bool($debug_timestamps) }
   unless empty($debug_microseconds) { validate_bool($debug_microseconds) }
 
-  concat_fragment { "sssd+${name}#local_provider.domain":
+  simpcat_fragment { "sssd+${name}#local_provider.domain":
     content => template('sssd/provider/local.erb')
   }
 }

--- a/manifests/service/autofs.pp
+++ b/manifests/service/autofs.pp
@@ -20,7 +20,7 @@ class sssd::service::autofs (
   unless empty($debug_microseconds) { validate_bool($debug_microseconds) }
   unless empty($autofs_negative_timeout) { validate_integer($autofs_negative_timeout) }
 
-  concat_fragment { 'sssd+autofs.service':
+  simpcat_fragment { 'sssd+autofs.service':
     content => template('sssd/service/autofs.erb')
   }
 }

--- a/manifests/service/nss.pp
+++ b/manifests/service/nss.pp
@@ -47,7 +47,7 @@ class sssd::service::nss (
   unless empty($memcache_timeout) { validate_integer($memcache_timeout) }
   validate_string($user_attributes)
 
-  concat_fragment { 'sssd+nss.service':
+  simpcat_fragment { 'sssd+nss.service':
     content => template('sssd/service/nss.erb')
   }
 

--- a/manifests/service/pac.pp
+++ b/manifests/service/pac.pp
@@ -20,7 +20,7 @@ class sssd::service::pac (
   unless empty($debug_microseconds) { validate_bool($debug_microseconds) }
   validate_array($allowed_uids)
 
-  concat_fragment { 'sssd+pac.service':
+  simpcat_fragment { 'sssd+pac.service':
     content => template('sssd/service/pac.erb')
   }
 }

--- a/manifests/service/pam.pp
+++ b/manifests/service/pam.pp
@@ -41,7 +41,7 @@ class sssd::service::pam (
 
   compliance_map()
 
-  concat_fragment { 'sssd+pam.service':
+  simpcat_fragment { 'sssd+pam.service':
     content => template('sssd/service/pam.erb')
   }
 }

--- a/manifests/service/ssh.pp
+++ b/manifests/service/ssh.pp
@@ -24,7 +24,7 @@ class sssd::service::ssh (
 
   compliance_map()
 
-  concat_fragment { 'sssd+ssh.service':
+  simpcat_fragment { 'sssd+ssh.service':
     content => template('sssd/service/ssh.erb')
   }
 }

--- a/manifests/service/sudo.pp
+++ b/manifests/service/sudo.pp
@@ -20,7 +20,7 @@ class sssd::service::sudo (
   unless empty($debug_microseconds) { validate_bool($debug_microseconds) }
   unless empty($sudo_timed) { validate_bool($sudo_timed) }
 
-  concat_fragment { 'sssd+sudo.service':
+  simpcat_fragment { 'sssd+sudo.service':
     content => template('sssd/service/sudo.erb')
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-sssd",
-  "version": "4.1.3",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,7 @@ describe 'sssd' do
         it { is_expected.to create_class('sssd::service') }
         it { is_expected.to contain_class('pki') }
 
-        it { is_expected.to contain_concat_build('sssd').with({
+        it { is_expected.to contain_simpcat_build('sssd').with({
             :target => '/etc/sssd/sssd.conf',
             :notify => '[File[/etc/sssd/sssd.conf]{:path=>"/etc/sssd/sssd.conf"}, Class[Sssd::Service]{:name=>"Sssd::Service"}]'
           })

--- a/spec/classes/service/nss_spec.rb
+++ b/spec/classes/service/nss_spec.rb
@@ -8,7 +8,7 @@ describe 'sssd::service::nss' do
 
         it { is_expected.to create_class('sssd::service::nss') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat_fragment('sssd+nss.service').without_content(%r(=\s*$)) }
+        it { is_expected.to contain_simpcat_fragment('sssd+nss.service').without_content(%r(=\s*$)) }
       end
     end
   end

--- a/spec/classes/service/pac_spec.rb
+++ b/spec/classes/service/pac_spec.rb
@@ -7,7 +7,7 @@ describe 'sssd::service::pac' do
         let(:facts){ facts }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('sssd+pac.service').without_content(%r(=\s*$)) }
+        it { is_expected.to create_simpcat_fragment('sssd+pac.service').without_content(%r(=\s*$)) }
       end
     end
   end

--- a/spec/classes/service/pam_spec.rb
+++ b/spec/classes/service/pam_spec.rb
@@ -7,7 +7,7 @@ describe 'sssd::service::pam' do
         let(:facts){ facts }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('sssd+pam.service').without_content(%r(=\s*$)) }
+        it { is_expected.to create_simpcat_fragment('sssd+pam.service').without_content(%r(=\s*$)) }
       end
     end
   end

--- a/spec/classes/service/ssh_spec.rb
+++ b/spec/classes/service/ssh_spec.rb
@@ -7,7 +7,7 @@ describe 'sssd::service::ssh' do
         let(:facts){ facts }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('sssd+ssh.service').without_content(%r(=\s*$)) }
+        it { is_expected.to create_simpcat_fragment('sssd+ssh.service').without_content(%r(=\s*$)) }
       end
     end
   end

--- a/spec/classes/service/sudo_spec.rb
+++ b/spec/classes/service/sudo_spec.rb
@@ -7,7 +7,7 @@ describe 'sssd::service::sudo' do
         let(:facts){ facts }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('sssd+sudo.service').without_content(%r(=\s*$)) }
+        it { is_expected.to create_simpcat_fragment('sssd+sudo.service').without_content(%r(=\s*$)) }
       end
     end
   end

--- a/spec/defines/domain_spec.rb
+++ b/spec/defines/domain_spec.rb
@@ -12,7 +12,7 @@ describe 'sssd::domain' do
         }}
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat_fragment('sssd+ldap#.domain').without_content(%r(=\s*$)) }
+        it { is_expected.to contain_simpcat_fragment('sssd+ldap#.domain').without_content(%r(=\s*$)) }
       end
     end
   end

--- a/spec/defines/provider/krb5_spec.rb
+++ b/spec/defines/provider/krb5_spec.rb
@@ -13,7 +13,7 @@ describe 'sssd::provider::krb5' do
         }}
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('sssd+krb5_test_domain#krb5_provider.domain').without_content(%r(=\s*$)) }
+        it { is_expected.to create_simpcat_fragment('sssd+krb5_test_domain#krb5_provider.domain').without_content(%r(=\s*$)) }
       end
     end
   end

--- a/spec/defines/provider/ldap_spec.rb
+++ b/spec/defines/provider/ldap_spec.rb
@@ -19,7 +19,7 @@ describe 'sssd::provider::ldap' do
         }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('sssd+test_ldap_provider#ldap_provider.domain').without_content(%r(=\s*$)) }
+        it { is_expected.to create_simpcat_fragment('sssd+test_ldap_provider#ldap_provider.domain').without_content(%r(=\s*$)) }
       end
     end
   end

--- a/spec/defines/provider/local_spec.rb
+++ b/spec/defines/provider/local_spec.rb
@@ -9,7 +9,7 @@ describe 'sssd::provider::local' do
         let(:title) {'test_local_domain'}
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('sssd+test_local_domain#local_provider.domain').without_content(%r(=\s*$)) }
+        it { is_expected.to create_simpcat_fragment('sssd+test_local_domain#local_provider.domain').without_content(%r(=\s*$)) }
       end
     end
   end


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'sssd'
