### PR TITLE
(SIMP-2427) Remove unnecessary dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,7 +10,6 @@ fixtures:
       branch: simp-master
     concat: https://github.com/simp/puppetlabs-concat
     logrotate: https://github.com/simp/pupmod-simp-logrotate
-    openldap: https://github.com/simp/pupmod-simp-openldap
     pki: https://github.com/simp/pupmod-simp-pki
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog
     simp: https://github.com/simp/pupmod-simp-simp


### PR DESCRIPTION
The openldap module is not requires for any sssd tests