### PR TITLE
(SIMP-2592) Refactored data-in-modules and added tests for OS data

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -4,3 +4,4 @@
 --no-140chars-check
 --no-trailing_comma-check
 --no-empty_string_assignment-check
+--no-parameter_order-check

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ To enable PKI
 simp_options::pki: true
 ```
 
+To enable Auditd
+```yaml
+simp_options::auditd: true
+```
+
 ### Beginning with SIMP SSSD
 
 The following will install and manage the service for SSSD, but will include no
@@ -121,6 +126,7 @@ The following services can be managed by `simp/sssd`:
 * sudo
 
 Please see sssd::service::<class> for more options on configuration
+Template files for these services are found in templates/services/class.erb
 
 ## Reference
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,76 @@
+---
+
+### These parameters control the installation and configuration of the sssd
+### package and its dependencies:
+sssd::client_package_name:     'sssd-client'
+sssd::client_package_version:  'latest'
+sssd::conf_file_path:          '/etc/sssd/sssd.conf'
+sssd::conf_dir_owner:          'root'      # RH / CentOS 6 - root, 7 - sssd
+sssd::conf_dir_path:           '/etc/sssd'
+sssd::install_user_tools:      true
+sssd::nscd_service_name:       'nscd'
+sssd::package_name:            'sssd'
+sssd::package_version:         'latest'
+sssd::sssd_service_path:       '/etc/init.d/sssd'
+sssd::sssd_service_name:       'sssd'
+sssd::tools_package_name:      'sssd-tools'
+sssd::tools_package_version:   'latest'
+
+### These parameters control the integration of the sssd module with
+### other SIMP modules and services. The variables that are commented out
+### are resolved using simplib::lookup, a special function that helps SIMP
+### integrate existing modules. Setting these values in hiera will supersede
+### simplib::lookup, and is not recommended. 
+sssd::app_pki_dir:              '/etc/pki/simp_apps/sssd/x509'
+# sssd::auditd:                 false      
+# sssd::pki:                    false          
+# sssd::app_pki_cert_source:    '/etc/pki/simp/x509' 
+
+### These parameters are only used inside templates that set values 
+### inside of the sssd config file (usually /etc/sssd/sssd.conf). 
+### You can find information about which variables a template is used in
+### in the init.pp manifest, and you can find a full list of the variables
+### used by a specific template inside that template's manifest. 
+sssd::allowed_uids:                      []
+sssd::autofs_negative_timeout:           null
+sssd::command:                           null
+sssd::config_file_version:               2
+sssd::debug_level:                       null
+sssd::debug_timestamps:                  true
+sssd::debug_microseconds:                false
+sssd::default_domain_suffix:             null
+sssd::default_shell:                     null
+sssd::description:                       null
+sssd::domains:                           null 
+sssd::entry_negative_timeout:            15
+sssd::entry_cache_nowait_percentage:     0
+sssd::enum_cache_timeout:                120
+sssd::fallback_homedir:                  null
+sssd::filter_groups:                     'root'
+sssd::filter_users:                      'root'  
+sssd::filter_users_in_groups:            true
+sssd::full_name_format:                  null
+sssd::get_domains_timeout:               null
+sssd::krb5_rcache_dir:                   null
+sssd::memcache_timeout:                  null
+sssd::offline_credentials_expiration:    0 
+sssd::offline_failed_login_attempts:     3
+sssd::offline_failed_login_delay:        5
+sssd::override_homedir:                  null
+sssd::override_shell:                    null
+sssd::override_space:                    null
+sssd::pam_verbosity:                     1
+sssd::pam_id_timeout:                    5
+sssd::pam_pwd_expiration_warning:        7
+sssd::pam_trusted_users:                 null
+sssd::pam_public_domains:                null
+sssd::reconnection_retries:              3
+sssd::re_expression:                     null
+sssd::services:                          ['nss','pam','ssh','sudo']
+sssd::ssh_hash_known_hosts:              true
+sssd::ssh_known_hosts_timeout:           null
+sssd::sudo_timed:                        false
+sssd::try_inotify:                       true
+sssd::user:                              null
+sssd::user_attributes:                   null
+sssd::vetoed_shells:                     null

--- a/data/os/RedHat/CentOS/6.yaml
+++ b/data/os/RedHat/CentOS/6.yaml
@@ -1,0 +1,3 @@
+---
+
+sssd::conf_dir_owner: 'root'

--- a/data/os/RedHat/CentOS/7.yaml
+++ b/data/os/RedHat/CentOS/7.yaml
@@ -1,0 +1,3 @@
+---
+
+sssd::conf_dir_owner: 'sssd'

--- a/data/os/RedHat/RedHat/6.yaml
+++ b/data/os/RedHat/RedHat/6.yaml
@@ -1,0 +1,3 @@
+---
+
+sssd::conf_dir_owner: 'root'

--- a/data/os/RedHat/RedHat/7.yaml
+++ b/data/os/RedHat/RedHat/7.yaml
@@ -1,0 +1,3 @@
+---
+
+sssd::conf_dir_owner: 'sssd'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,26 @@
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "Full Version"
+    backend: yaml
+    path: "os/%{facts.os.name}/%{facts.os.release.full}"
+
+  - name: "Major / Minor Version"
+    backend: yaml
+    path: "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}/%{facts.os.release.minor}"
+
+  - name: "Major Version"
+    backend: yaml
+    path: "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}"
+
+  - name: "Operating System Name"
+    backend: yaml
+    path: "os/%{facts.os.family}/%{facts.os.name}"
+
+  - name: "Operating System Family"
+    backend: yaml
+    path: "os/%{facts.os.family}"
+
+  - name: "common"
+    backend: yaml        

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -67,12 +67,13 @@ define sssd::domain (
   Boolean                                    $proxy_fast_alias             = false,
   Optional[String]                           $realmd_tags                  = undef,
   Optional[String]                           $proxy_pam_target             = undef,
-  Optional[String]                           $proxy_lib_name               = undef
+  Optional[String]                           $proxy_lib_name               = undef,
+  Stdlib::Absolutepath                       $conf_file_path               = simplib::lookup('sssd::conf_file_path', { 'default_value' => '/etc/sssd/sssd.conf' })
 ) {
   include '::sssd'
 
   concat::fragment { "sssd_${name}_.domain":
-    target  => '/etc/sssd/sssd.conf',
+    target  => $conf_file_path,
     content => template('sssd/domain.erb')
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,60 +1,424 @@
 # == Class: sssd
 #
 # This class allows you to install and configure SSSD.
-#
 # It will forcefully disable nscd which consequently prevents you from using an
 # nscd module at the same time, which is the correct behavior.  ---
 #
-# == Parameters:
-#
-# @param pki
-#   * If 'simp', include SIMP's pki module and use pki::copy to manage
-#     application certs in /etc/pki/simp_apps/sssd/x509
-#   * If true, do *not* include SIMP's pki module, but still use pki::copy
-#     to manage certs in /etc/pki/simp_apps/sssd/x509
-#   * If false, do not include SIMP's pki module and do not use pki::copy
-#     to manage certs.  You will need to appropriately assign a subset of:
-#     * app_pki_dir
-#     * app_pki_key
-#     * app_pki_cert
-#     * app_pki_ca
-#     * app_pki_ca_dir
-#
-# @param app_pki_external_source
-#   * If pki = 'simp' or true, this is the directory from which certs will be
-#     copied, via pki::copy.  Defaults to /etc/pki/simp/x509.
-#
-#   * If pki = false, this variable has no effect.
-#
-# @param app_pki_dir
-#   This variable controls the basepath of $app_pki_key, $app_pki_cert,
-#   $app_pki_ca, $app_pki_ca_dir, and $app_pki_crl.
-#   It defaults to /etc/pki/simp_apps/sssd/x509.
-#
 # == Authors
 #
-# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
+# == Parameters:
+#
+# === Installation / Configuration Parameters ===
+# The following parameters allow you to control the installation and
+# configuration of the sssd package.
+#
+# @param client_package_name [Optional[String]]
+#   The name of the sssd client package (varies by OS)
+#   Default value: 'sssd-client'
+#
+# @param client_package_version [Optional[String]]
+#   The version of the sssd client package
+#   Default value: 'latest'
+#
+# @param conf_file_path [Stdlib::Absoultepath]
+#   The path to the configuration file for sssd.
+#   Default value: '/etc/sssd/sssd.conf'
+#
+# @param conf_dir_owner [Optional[String]]
+#   The owner of the sssd configuration directory.
+#   Default value: 'sssd'
+#     On RHEL-6 and before, and CentOS-6 and before: 'root'
+#
+# @param conf_dir_path [Stdlib::Absolutepath]
+#   The sssd configuration directory.
+#   Default value: '/etc/sssd/'
+#
+# @param install_user_tools [Boolean]
+#   Determines if this module should install the sssd tools package
+#   Default value: true
+#
+# @param nscd_service_name [Optional[String]]
+#   The name of the nscd service. sssd cannot coexist with nscd, so this
+#   module will disable it. This is intended behavior.
+#   Default value: 'nscd'
+#
+# @param package_name [Optional[String]]
+#   The name of the sssd package that will be installed.
+#   Default value: 'sssd'
+#
+# @param package_version [Optional[String]]
+#   The version of the package to be installed.
+#   Default value: 'latest'
+#
+# @param sssd_service_path [Stdlib::Absolutepath]
+#   The path to the service executable for the sssd service
+#   Default value: '/etc/init.d/sssd'
+#
+# @param sssd_service_name [Optional[String]]
+#   The name of the sssd service
+#   Default value: 'sssd'
+#
+# @param tools_package_name [Optional[String]]
+#   The name of the sssd tools package
+#   Default value: 'sssd-tools'
+#
+# @param tools_package_version [Optional[String]]
+#   The version of the tools package to be installed
+#   Default value: 'latest'
+#
+# === SIMP Integration Parameters ===
+# These parameters control the integration of the sssd module with
+# other SIMP modules and services. The variables that are being set here are
+# resolved using simplib::lookup, a special function that helps SIMP
+# integrate existing modules. Setting these values in hiera will supersede
+# simplib::lookup, and is not recommended.
+#
+# @param app_pki_dir [Stdlib::Absolutepath]
+#   Controls the basepath of the $app_pki_key, $app_pki_cert,
+#   $app_pki_ca, $app_pki_ca_dir, and $app_pki_crl parameters.
+#   Default value: '/etc/pki/simp_apps/sssd/x509'
+#
+# @param auditd [Boolean]
+#   Determines if auditd is enabled at a global level. If it is,
+#   this module will take steps to ensure sssd and auditd work
+#   together.
+#   Default value: false
+#
+# @param pki [[Boolean,Enum['simp']]]
+#   Determines if pki is enabled at a global level. If it is,
+#   this module will take steps to ensure that sssd and pki work
+#   together.
+#   Default value: false
+#
+# @param app_pki_cert_source [Stdlib::Absolutepath]
+#   Determines the location that pki will look for certificates.
+#   Default value: '/etc/pki/simp/x509'
+#
+# === Template Parameters ===
+# The following parameters are exposed here, but are only used inside of
+# templates that configure the sections of the sssd configuration file.
+# Futher information about which parameters are available to each section
+# of the configuration file can be found inside the manifests that control
+# the corresponding sections. (ex: manifests/service/pam.pp)
+#
+# @param allowed_uids [Array[String]]
+#   Sets the allowed_uids field in the pac section of the sssd config file.
+#   Default value: []
+#   Used in: templates/service/pac.erb
+#
+# @param autofs_negative_timeout [Optional[Integer]]
+#   Sets autofs_negative_timeout in the autofs section of the sssd config file
+#   Default value: null
+#   Used in: templates/service/autofs.erb
+#
+# @param command [Optional[String]]
+#   Sets command in the nss and pam sections of the sssd config file
+#   Default value: null
+#   Used in: templates/service/nss.erb
+#            templates/service/pam.erb
+#
+# @param config_file_version [Integer]
+#   Sets config_file_version in the sssd section of the sssd config file
+#   Default value: 2
+#   Used in: templates/sssd.conf.erb
+#
+# @param debug_level [Optional[Sssd::DebugLevel]]
+#   Sets debug_level in each section of the config file.
+#   Default value: null
+#   Used in: templates/domain.erb
+#            templates/provider/krb5.erb
+#            templates/provider/ldap.erb
+#            templates/provider/local.erb
+#            templates/service/autofs.erb
+#            templates/service/nss.erb
+#            templates/service/pac.erb
+#            templates/service/pam.erb
+#            templates/service/ssh.erb
+#            templates/service/sudo.erb
+#            templates/sssd.conf.erb
+#
+# @param debug_timestamps [Boolean]
+#   Turns on or off debug_timestamps in each section of the config file.
+#   Default value: true
+#   Used in: -see debug_level param-
+#
+# @param debug_microseconds [Boolean]
+#   Turns on or off debug_microseconds in each section of the config file.
+#   Default value: false
+#   Used in: -see debug_level param-
+#
+# @param default_domain_suffix [Optional[String]]
+#   Sets the default_domain_suffix in the sssd section of sssd config file.
+#   Default value: null
+#   Used in: templates/sssd.conf.erb
+#
+# @param default_shell [Optional[String]]
+#   Sets the default_shell in local, nss sections of the sssd config file.
+#   Default value: null
+#   Used in: templates/provider/local.erb
+#            templates/service/nss.erb
+#
+# @param description [Optional[String]]
+#   Sets the desciption in each of the sections of the sssd config file.
+#   Default value: null
+#   Used in: -see debug_level param-
+#
+# @param domains [Array[String]]
+#   Sets the domains field in the sssd section of the sssd config file.
+#   Default value: null
+#   Used in: templates/sssd.conf.erb
+#
+# @param entry_negative_timeout [Integer]
+#   Sets the entry_negative_timeout field in the nss section of config file.
+#   Default value: 15
+#   Used in: templates/service/nss.erb
+#
+# @param entry_cache_nowait_percentage [Integer]
+#   Sets the entry_cache_nowait_percentage field in the nss section of config.
+#   Default value: 0
+#   Used in: templates/service/nss.erb
+#
+# @param enum_cache_timeout [Integer]
+#   Sets the enum_cache_timeout field in the nss section of the config file.
+#   Default value: 120
+#   Used in: templates/service/nss.erb
+#
+# @param fallback_homedir [Optional[String]]
+#   Sets the fallback_homedir field in the nss section of the config file.
+#   Default value: null
+#   Used in: templates/service/nss.erb
+#
+# @param filter_users [String]
+#   Sets the filter_users field in the nss section of the config file.
+#   Default value: 'root'
+#   Used in: templates/service/nss.erb
+#
+# @param filter_users_in_groups [Boolean]
+#   Sets the value of the filter_users_in_groups field inside the nss
+#   section of the sssd config file.
+#   Default value: true
+#   Used in: templates/service/nss.erb
+#
+# @param filter_groups [String]
+#   Sets the filter_groups field inside the nss section of config file.
+#   Default value: 'root'
+#   Used in: templates/service/nss.erb
+#
+# @param full_name_format [Optional[String]]
+#   Sets the full_name_format field inside the sssd and domain sections
+#   of the sssd config file.
+#   Default value: null
+#   Used in: templates/sssd.conf.erb
+#            templates/domain.erb
+#
+# @param get_domains_timeout [Optional[Integer]]
+#   Sets the value of the get_domains_timeout field inside the nss
+#   and pam sections of the sssd config file.
+#   Default value: null
+#   Used in: templates/service/nss.erb
+#            templates/service/pam.erb
+#
+# @param krb5_rcache_dir [Optional[String]]
+#   Sets the value of the krb5_rcache_dir field inside the sssd
+#   section of the sssd config file.
+#   Default value: null
+#   Used in: templates/sssd.conf.erb
+#
+# @param memcache_timeout [Optional[Integer]]
+#   Sets the value of memcache_timeout in the nss section of the config file
+#   Default value: null
+#   Used in: templates/service/nss.erb
+#
+# @param offline_credentials_expiration [Integer]
+#   Sets offline_credentials_expiration inside the pam section of config file
+#   Default value: 0
+#   Used in: templates/service/pam.erb
+#
+# @param offline_failed_login_attempts [Integer]
+#   Sets the value of the offline_failed_login_attempts field inside the pam
+#   section of the sssd config file.
+#   Default value: 3
+#   Used in: templates/service/pam.erb
+#
+# @param offline_failed_login_delay [Integer]
+#   Sets the value of the offline_failed_login_delay field inside the
+#   pam section of the sssd config file.
+#   Default Value: 5
+#   Used in: templates/service/pam.erb
+#
+# @param override_homedir [Optional[String]]
+#   Sets override_homedir in the ad and nss sections of the config file
+#   Default value: null
+#   Used in: templates/service/nss.erb
+#            templates/provider/ad.erb
+#
+# @param override_shell [Optional[String]]
+#   Sets override_shell in the nss section of the config file
+#   Default value: null
+#   Used in: templates/service/nss.erb
+#
+# @param override_space [Optional[String]]
+#   Sets override_homedir in the sssd section of the config file
+#   Default value: null
+#   Used in: templates/sssd.conf.erb
+#
+# @param pam_verbosity [Integer]
+#   Sets the value of pam_verbosity in the pam section of the config file.
+#   Default value: 1
+#   Used in: templates/service/pam.erb
+#
+# @param pam_id_timeout [Integer]
+#   Sets the value of pam_id_timeout in the pam section of the config file.
+#   Default value: 5
+#   Used in: templates/service/pam.erb
+#
+# @param pam_pwd_expiration_warning [Integer]
+#   Sets pam_pwd_expiration_warning in the pam section of the config file.
+#   Default value: 7
+#   Used in: templates/service/pam.erb
+#
+# @param pam_trusted_users [Optional[String]]
+#   Sets pam_trusted_users in the pam section of the config file.
+#   Default value: null
+#   Used in: templates/service/pam.erb
+#
+# @param pam_public_domains [Optional[String]]
+#   Sets pam_public_domains in the pam section of the config file.
+#   Default value: null
+#   Used in: templates/service/pam.erb
+#
+# @param reconnection_retries [Integer]
+#   Sets the value of reconnection_retries in the nss, pam, and sssd sections
+#   of the sssd config file.
+#   Default value: 3
+#   Used in: templates/service/pam.erb
+#            templates/service/nss.erb
+#            templates/sssd.conf.erb
+#
+# @param re_expression [Optional[String]]
+#   Sets re_expression in the domain and sssd sections of the config file.
+#   Default value: null
+#   Used in: templates/sssd.conf.erb
+#            templates/domain.erb
+#
+# @param services [Sssd::Services]
+#   Sets the value of services in the sssd section of the config file.
+#   Default value: ['nss','pam','ssh','sudo']
+#   Used in: templates/sssd.conf.erb
+#
+# @param ssh_hash_known_hosts [Boolean]
+#   Sets the value of ssh_hash_known_hosts in the ssh section of the config
+#   Default value: true
+#   Used in: templates/service/ssh.erb
+#
+# @param ssh_known_hosts_timeout [Optional[Integer]]
+#   Sets the value of sssh_known_hosts_timeout in the ssh section of config
+#   Default value: null
+#   Used in: templates/service/ssh.erb
+#
+# @param sudo_timed [Boolean]
+#   Sets the value of sudo_timed in the sudo section of the config file.
+#   Default value: false
+#   Used in: templates/service/sudo.erb
+#
+# @param try_inotify [Boolean]
+#   Sets the try_inotify field in the sssd section of the conf file
+#   Default value: true
+#   Used in: templates/service/ssh.conf.erb
+#
+# @param user [Optional[String]]
+#   Sets the value of the user field in the sssd section of the conf file.
+#   Default value: null
+#   Used in: templates/sssd.conf.erb
+#
+# @param user_attributes [Optional[String]]
+#   Sets the user_attributes field in the nss section of the conf file
+#   Default value: null
+#   Used in: templates/service/nss.erb
+#
+# @param vetoed_shells [Optional[String]]
+#   Sets the value of the vetoed_shells field in the nss section of sssd conf
+#   Default value: null
+#   Used in: templates/service/nss.erb
+#
+
 class sssd (
+
+  ## These variables control the initial installation and configuration
+  ## of the sssd package and its dependencies.
+  Optional[String]               $client_package_name,
+  Optional[String]               $client_package_version,
+  Stdlib::Absolutepath           $conf_file_path,
+  Optional[String]               $conf_dir_owner,
+  Stdlib::Absolutepath           $conf_dir_path,
+  Boolean                        $install_user_tools,
+  Optional[String]               $nscd_service_name,
+  Optional[String]               $package_name,
+  Optional[String]               $package_version,
+  Stdlib::Absolutepath           $sssd_service_path,
+  Optional[String]               $sssd_service_name,
+  Optional[String]               $tools_package_name,
+  Optional[String]               $tools_package_version,
+
+  ## These parameters control integration of the sssd module with other SIMP
+  ## modules / services.
+  Stdlib::Absolutepath           $app_pki_dir,
+  Boolean                        $auditd               = simplib::lookup('simp_options::auditd', { 'default_value' => false}),
+  Variant[Boolean,Enum['simp']]  $pki                  = simplib::lookup('simp_options::pki', { 'default_value' => false}),
+  Stdlib::Absolutepath           $app_pki_cert_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509'}),
+
+  ## The following parameters are exposed here, but are only used inside of
+  ## templates that configure the sections of the sssd configuration file.
+  ## Futher information about which parameters are available to each section
+  ## of the configuration file can be found inside the manifests that control
+  ## the corresponding sections. (ex: manifests/service/pam.pp)
+
+  Array[String]                  $allowed_uids,
+  Optional[Integer]              $autofs_negative_timeout,
+  Optional[String]               $command,
+  Integer                        $config_file_version,
+  Optional[Sssd::DebugLevel]     $debug_level,
+  Boolean                        $debug_timestamps,
+  Boolean                        $debug_microseconds,
+  Optional[String]               $default_domain_suffix,
+  Optional[String]               $default_shell,
+  Optional[String]               $description,
   Array[String]                  $domains,
-  Optional[String]               $debug_level           = undef,
-  Boolean                        $debug_timestamps      = true,
-  Boolean                        $debug_microseconds    = false,
-  Optional[String]               $description           = undef,
-  Integer                        $config_file_version   = 2,
-  Sssd::Services                 $services              = ['nss','pam','ssh','sudo'],
-  Integer                        $reconnection_retries  = 3,
-  Optional[String]               $re_expression         = undef,
-  Optional[String]               $full_name_format      = undef,
-  Boolean                        $try_inotify           = true,
-  Optional[String]               $krb5_rcache_dir       = undef,
-  Optional[String]               $user                  = undef,
-  Optional[String]               $default_domain_suffix = undef,
-  Optional[String]               $override_space        = undef,
-  Boolean                        $auditd                = simplib::lookup('simp_options::auditd', { 'default_value' => false}),
-  Variant[Boolean,Enum['simp']]  $pki                   = simplib::lookup('simp_options::pki', { 'default_value' => false}),
-  Stdlib::Absolutepath           $app_pki_cert_source   = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509'}),
-  Stdlib::Absolutepath           $app_pki_dir           = '/etc/pki/simp_apps/sssd/x509'
+  Integer                        $entry_negative_timeout,
+  Integer                        $entry_cache_nowait_percentage,
+  Integer                        $enum_cache_timeout,
+  Optional[String]               $fallback_homedir,
+  String                         $filter_users,
+  Boolean                        $filter_users_in_groups,
+  String                         $filter_groups,
+  Optional[String]               $full_name_format,
+  Optional[Integer]              $get_domains_timeout,
+  Optional[String]               $krb5_rcache_dir,
+  Optional[Integer]              $memcache_timeout,
+  Integer                        $offline_credentials_expiration,
+  Integer                        $offline_failed_login_attempts,
+  Integer                        $offline_failed_login_delay,
+  Optional[String]               $override_homedir,
+  Optional[String]               $override_shell,
+  Optional[String]               $override_space,
+  Integer                        $pam_verbosity,
+  Integer                        $pam_id_timeout,
+  Integer                        $pam_pwd_expiration_warning,
+  Optional[String]               $pam_trusted_users,
+  Optional[String]               $pam_public_domains,
+  Integer                        $reconnection_retries,
+  Optional[String]               $re_expression,
+  Sssd::Services                 $services,
+  Boolean                        $ssh_hash_known_hosts,
+  Optional[Integer]              $ssh_known_hosts_timeout,
+  Boolean                        $sudo_timed,
+  Boolean                        $try_inotify,
+  Optional[String]               $user,
+  Optional[String]               $user_attributes,
+  Optional[String]               $vetoed_shells,
+
 ) {
 
   include '::sssd::install'
@@ -64,11 +428,11 @@ class sssd (
     include '::auditd'
 
     auditd::rule { 'sssd':
-      content => '-w /etc/sssd/ -p wa -k CFG_sssd'
+      content => "-w ${sssd::conf_dir_path}/ -p wa -k CFG_sssd"
     }
   }
 
-  concat { '/etc/sssd/sssd.conf':
+  concat { $sssd::conf_file_path:
     owner          => 'root',
     group          => 'root',
     mode           => '0640',
@@ -78,7 +442,7 @@ class sssd (
   }
 
   concat::fragment { 'sssd_main_config':
-    target  => '/etc/sssd/sssd.conf',
+    target  => $conf_file_path,
     content => template("${module_name}/sssd.conf.erb")
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,48 +2,35 @@
 #
 # Install the required packages for SSSD
 #
-# == Parameters:
-#
-# [*install_user_tools*]
-# Type: Boolean
-# Default: true
-#   If true, install the 'sssd-tools' for administrative changes to the SSSD
-#   databases.
-#
 # == Authors
 #
 # * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
-class sssd::install (
-  Boolean  $install_user_tools = true
-) {
+class sssd::install {
   contain '::sssd::install::client'
 
-
-  if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::operatingsystemmajrelease > '6' ) {
-    $_sssd_user = 'sssd'
-  } else {
-    $_sssd_user = 'root'
-  }
-
-  file { '/etc/sssd':
+  file { $sssd::conf_dir_path:
     ensure  => 'directory',
-    owner   => $_sssd_user,
+    owner   => $sssd::conf_dir_owner,
     group   => 'root',
     mode    => '0640',
-    require => Package['sssd']
+    require => Package[$sssd::package_name]
   }
 
-  file { '/etc/sssd/sssd.conf':
+  file { $sssd::conf_file_path:
     ensure => 'file',
     owner  => 'root',
     group  => 'root',
     mode   => '0600'
   }
 
-  package { 'sssd': ensure => 'latest' }
+  package { $sssd::package_name:
+    ensure => $sssd::package_version
+  }
 
-  if $install_user_tools {
-    package { 'sssd-tools': ensure => 'latest' }
+  if $sssd::install_user_tools {
+    package { $sssd::tools_package_name:
+      ensure => $sssd::tools_package_version
+    }
   }
 }

--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -2,8 +2,6 @@
 #
 # Install the sssd-client package
 #
-class sssd::install::client (
-  $ensure = 'latest'
-){
-  package { 'sssd-client': ensure => $ensure }
+class sssd::install::client {
+  package { $sssd::client_package_name: ensure => $sssd::client_package_version }
 }

--- a/manifests/provider/ad.pp
+++ b/manifests/provider/ad.pp
@@ -124,12 +124,13 @@ define sssd::provider::ad (
   Optional[String]                                           $ldap_idmap_default_domain_sid            = undef,
   Optional[String]                                           $ldap_idmap_default_domain                = undef,
   Optional[Boolean]                                          $ldap_idmap_autorid_compat                = undef,
-  Optional[Integer[1]]                                       $ldap_idmap_helper_table_size             = undef
+  Optional[Integer[1]]                                       $ldap_idmap_helper_table_size             = undef,
+  Stdlib::Absolutepath                                       $conf_file_path                           = simplib::lookup('sssd::conf_file_path', { 'default_value' =>  '/etc/sssd/sssd.conf' })
 ) {
   include '::sssd'
 
   concat::fragment { "sssd_${name}_ad_provider.domain":
-    target  => '/etc/sssd/sssd.conf',
+    target  => $conf_file_path,
     content => template("${module_name}/provider/ad.erb")
   }
 }

--- a/manifests/provider/krb5.pp
+++ b/manifests/provider/krb5.pp
@@ -29,12 +29,13 @@ define sssd::provider::krb5 (
   Optional[String]                       $krb5_renewable_lifetime        = undef,
   Optional[String]                       $krb5_lifetime                  = undef,
   Integer                                $krb5_renew_interval            = 0,
-  Optional[Enum['never','try','demand']] $krb5_use_fast                  = undef
+  Optional[Enum['never','try','demand']] $krb5_use_fast                  = undef,
+  Stdlib::Absolutepath                   $conf_file_path                 = simplib::lookup('sssd::conf_file_path', { 'default_value' => '/etc/sssd/sssd.conf' })
 ) {
   include '::sssd'
 
   concat::fragment { "sssd_${name}_krb5_provider.domain":
-    target  => '/etc/sssd/sssd.conf',
+    target  => $conf_file_path,
     content => template("${module_name}/provider/krb5.erb")
   }
 }

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -169,7 +169,8 @@ define sssd::provider::ldap (
   Optional[Integer[0]]                  $ldap_idmap_range_size             = undef,
   Optional[String]                      $ldap_idmap_default_domain_sid     = undef,
   Optional[String]                      $ldap_idmap_default_domain         = undef,
-  Boolean                               $ldap_idmap_autorid_compat         = false
+  Boolean                               $ldap_idmap_autorid_compat         = false,
+  Stdlib::Absolutepath                  $conf_file_path                    = simplib::lookup('sssd::conf_file_path', { 'default_value' => '/etc/sssd/sssd.conf' })
 ) {
   include '::sssd'
 
@@ -192,7 +193,7 @@ define sssd::provider::ldap (
   }
 
   concat::fragment { "sssd_${name}_ldap_provider.domain":
-    target  => '/etc/sssd/sssd.conf',
+    target  => $conf_file_path,
     content => template('sssd/provider/ldap.erb')
   }
 }

--- a/manifests/provider/local.pp
+++ b/manifests/provider/local.pp
@@ -24,12 +24,13 @@ define sssd::provider::local (
   Optional[Simplib::Umask]        $homedir_umask      = undef,
   Optional[Stdlib::Absolutepath]  $skel_dir           = undef,
   Optional[Stdlib::Absolutepath]  $mail_dir           = undef,
-  Optional[String]                $userdel_cmd        = undef
+  Optional[String]                $userdel_cmd        = undef,
+  Stdlib::Absolutepath            $conf_file_path     = simplib::lookup('sssd::conf_file_path', { 'default_value' => '/etc/sssd/sssd.conf' })
 ) {
   include '::sssd'
 
   concat::fragment { "sssd_${name}_local_provider.domain":
-    target  => '/etc/sssd/sssd.conf',
+    target  => $conf_file_path,
     content => template('sssd/provider/local.erb')
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,30 +5,30 @@
 # == Authors
 #
 # * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
-#
+
 class sssd::service {
 
-  file { '/etc/init.d/sssd':
+  file { $sssd::sssd_service_path:
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0754',
     seltype => 'sssd_initrc_exec_t',
     source  => 'puppet:///modules/sssd/sssd.sysinit',
-    notify  => Service['sssd']
+    notify  => Service[$sssd::sssd_service_name]
   }
 
-  service { 'nscd':
+  service { $sssd::nscd_service_name:
     ensure => 'stopped',
     enable => false,
-    notify => Service['sssd']
+    notify => Service[$sssd::sssd_service_name]
   }
 
-  service { 'sssd':
+  service { $sssd::sssd_service_name:
     ensure     => 'running',
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    require    => File['/etc/init.d/sssd']
+    require    => File[$sssd::sssd_service_path]
   }
 }

--- a/manifests/service/autofs.pp
+++ b/manifests/service/autofs.pp
@@ -6,17 +6,30 @@
 #
 # == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
-class sssd::service::autofs (
-  Optional[String]            $description              = undef,
-  Optional[Sssd::DebugLevel]  $debug_level              = undef,
-  Boolean                     $debug_timestamps         = true,
-  Boolean                     $debug_microseconds       = false,
-  Optional[Integer]           $autofs_negative_timeout  = undef,
-) {
+#
+# === Parameters Available in this Template:
+# $autofs_negative_timeout
+# $debug_level
+# $debug_timestamps
+# $debug_microseconds
+# $description
+
+class sssd::service::autofs {
+
   include '::sssd'
 
+  # These varaibles are referenced inside the autofs template, and 
+  # because we don't want to worry about scope inside of the template
+  # we handle it here. 
+
+  $autofs_negative_timeout = $sssd::autofs_negative_timeout
+  $debug_level             = $sssd::debug_level
+  $debug_timestamps        = $sssd::debug_timestamps
+  $debug_microseconds      = $sssd::debug_microseconds
+  $description             = $sssd::description
+
   concat::fragment { 'sssd_autofs.service':
-    target  => '/etc/sssd/sssd.conf',
+    target  => $sssd::conf_file_path,
     content => template("${module_name}/service/autofs.erb")
   }
 }

--- a/manifests/service/nss.pp
+++ b/manifests/service/nss.pp
@@ -7,33 +7,59 @@
 #
 # * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
-class sssd::service::nss (
-  Optional[String]             $description                   = undef,
-  Optional[Sssd::DebugLevel]   $debug_level                   = undef,
-  Boolean                      $debug_timestamps              = true,
-  Boolean                      $debug_microseconds            = false,
-  Integer                      $reconnection_retries          = 3,
-  Optional[Integer]            $fd_limit                      = undef,
-  Optional[String]             $command                       = undef,
-  Integer                      $enum_cache_timeout            = 120,
-  Integer                      $entry_cache_nowait_percentage = 0,
-  Integer                      $entry_negative_timeout        = 15,
-  String                       $filter_users                  = 'root',
-  String                       $filter_groups                 = 'root',
-  Boolean                      $filter_users_in_groups        = true,
-  Optional[String]             $override_homedir              = undef,
-  Optional[String]             $fallback_homedir              = undef,
-  Optional[String]             $override_shell                = undef,
-  Optional[String]             $vetoed_shells                 = undef,
-  Optional[String]             $default_shell                 = undef,
-  Optional[Integer]            $get_domains_timeout           = undef,
-  Optional[Integer]            $memcache_timeout              = undef,
-  Optional[String]             $user_attributes               = undef
-) {
+# === Parameters Available in this Template:
+# command
+# description
+# debug_level
+# debug_timestamps
+# debug_microseconds
+# default_shell
+# entry_cache_nowait_percentage
+# entry_negative_timeout
+# enum_cache_timeout
+# fallback_homedir
+# filter_users
+# filter_groups
+# fiter_users_in_groups
+# get_domains_timeout
+# memcache_timeout
+# override_homedir
+# override_shell
+# reconnection_retries
+# user_attributes
+# vetoed_shells
+
+class sssd::service::nss {
+
   include '::sssd'
 
+  # These varaibles are referenced inside the autofs template, and
+  # because we don't want to worry about scope inside of the template
+  # we handle it here.
+
+  $description                   = $sssd::description
+  $debug_level                   = $sssd::debug_level
+  $debug_timestamps              = $sssd::debug_timestamps
+  $debug_microseconds            = $sssd::debug_microseconds
+  $reconnection_retries          = $sssd::reconnection_retries
+  $command                       = $sssd::command
+  $enum_cache_timeout            = $sssd::enum_cache_timeout
+  $entry_cache_nowait_percentage = $sssd::entry_cache_nowait_percentage
+  $entry_negative_timeout        = $sssd::entry_negative_timeout
+  $filter_users                  = $sssd::filter_users
+  $filter_groups                 = $sssd::filter_groups
+  $filter_users_in_groups        = $sssd::filter_users_in_groups
+  $override_homedir              = $sssd::override_homedir
+  $fallback_homedir              = $sssd::fallback_homedir
+  $override_shell                = $sssd::override_shell
+  $vetoed_shells                 = $sssd::vetoed_shells
+  $default_shell                 = $sssd::default_shell
+  $get_domains_timeout           = $sssd::get_domains_timeout
+  $memcache_timeout              = $sssd::memcache_timeout
+  $user_attributes               = $sssd::user_attributes
+
   concat::fragment { 'sssd_nss.service':
-    target  => '/etc/sssd/sssd.conf',
+    target  => $sssd::conf_file_path,
     content => template("${module_name}/service/nss.erb")
   }
 }

--- a/manifests/service/pac.pp
+++ b/manifests/service/pac.pp
@@ -6,17 +6,29 @@
 #
 # == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
-class sssd::service::pac (
-  Optional[String]             $description        = undef,
-  Optional[Sssd::DebugLevel]   $debug_level        = undef,
-  Boolean                      $debug_timestamps   = true,
-  Boolean                      $debug_microseconds = false,
-  Array[String]                $allowed_uids       = []
-) {
+# == Parameters available in this template:
+# allowed_uids
+# debug_level
+# debug_timestamps
+# debug_microseconds
+# description
+
+class sssd::service::pac {
+
   include '::sssd'
 
+  # These varaibles are referenced inside the autofs template, and
+  # because we don't want to worry about scope inside of the template
+  # we handle it here.
+
+  $description        = $sssd::description
+  $debug_level        = $sssd::debug_level
+  $debug_timestamps   = $sssd::debug_timestamps
+  $debug_microseconds = $sssd::debug_microseconds
+  $allowed_uids       = $sssd::allowed_uids
+
   concat::fragment { 'sssd_pac.service':
-    target  => '/etc/sssd/sssd.conf',
+    target  => $sssd::conf_file_path,
     content => template("${module_name}/service/pac.erb")
   }
 }

--- a/manifests/service/pam.pp
+++ b/manifests/service/pam.pp
@@ -7,27 +7,49 @@
 #
 # == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
-class sssd::service::pam (
-  Optional[String]             $description                    = undef,
-  Optional[Sssd::DebugLevel]   $debug_level                    = undef,
-  Boolean                      $debug_timestamps               = true,
-  Boolean                      $debug_microseconds             = false,
-  Integer                      $reconnection_retries           = 3,
-  Optional[String]             $command                        = undef,
-  Integer                      $offline_credentials_expiration = 0,
-  Integer                      $offline_failed_login_attempts  = 3,
-  Integer                      $offline_failed_login_delay     = 5,
-  Integer                      $pam_verbosity                  = 1,
-  Integer                      $pam_id_timeout                 = 5,
-  Integer                      $pam_pwd_expiration_warning     = 7,
-  Optional[Integer]            $get_domains_timeout            = undef,
-  Optional[String]             $pam_trusted_users              = undef,
-  Optional[String]             $pam_public_domains             = undef
-) {
+# == Parameters available to this template
+# command
+# debug_level
+# debug_timestamps
+# debug_microseconds
+# description
+# get_domains_timeout
+# offline_credentials_expiration
+# offline_failed_login_attempts
+# offline_failed_login_delay
+# pam_id_timeout
+# pam_pwd_expiration_warning
+# pam_public_domains
+# pam_trusted_users
+# pam_verbosity
+# reconnection_retries
+
+class sssd::service::pam {
+
   include '::sssd'
 
+  # These varaibles are referenced inside the autofs template, and
+  # because we don't want to worry about scope inside of the template
+  # we handle it here.
+
+  $description                    = $sssd::description
+  $debug_level                    = $sssd::debug_level
+  $debug_timestamps               = $sssd::debug_timestamps
+  $debug_microseconds             = $sssd::debug_microseconds
+  $reconnection_retries           = $sssd::reconnection_retries
+  $command                        = $sssd::command
+  $offline_credentials_expiration = $sssd::offline_credentials_expiration
+  $offline_failed_login_attempts  = $sssd::offline_failed_login_attempts
+  $offline_failed_login_delay     = $sssd::offline_failed_login_delay
+  $pam_verbosity                  = $sssd::pam_verbosity
+  $pam_id_timeout                 = $sssd::pam_id_timeout
+  $pam_pwd_expiration_warning     = $sssd::pam_pwd_expiration_warning
+  $get_domains_timeout            = $sssd::get_domains_timeout
+  $pam_trusted_users              = $sssd::pam_trusted_users
+  $pam_public_domains             = $sssd::pam_public_domains
+
   concat::fragment { 'sssd_pam.service':
-    target  => '/etc/sssd/sssd.conf',
+    target  => $sssd::conf_file_path,
     content => template("${module_name}/service/pam.erb")
   }
 }

--- a/manifests/service/ssh.pp
+++ b/manifests/service/ssh.pp
@@ -6,18 +6,32 @@
 #
 # == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
-class sssd::service::ssh (
-  Optional[String]             $description             = undef,
-  Optional[Sssd::DebugLevel]   $debug_level             = undef,
-  Boolean                      $debug_timestamps        = true,
-  Boolean                      $debug_microseconds      = false,
-  Boolean                      $ssh_hash_known_hosts    = true,
-  Optional[Integer]            $ssh_known_hosts_timeout = undef
-) {
+# == Parameters available to this template:
+# debug_level
+# debug_timestampts
+# debug_microseconds
+# description
+# ssh_hash_known_hosts
+# ssh_known_hosts_timeout
+#
+
+class sssd::service::ssh {
+
   include '::sssd'
 
+  # These varaibles are referenced inside the autofs template, and
+  # because we don't want to worry about scope inside of the template
+  # we handle it here.
+
+  $description             = $sssd::description
+  $debug_level             = $sssd::debug_level
+  $debug_timestamps        = $sssd::debug_timestamps
+  $debug_microseconds      = $sssd::debug_microseconds
+  $ssh_hash_known_hosts    = $sssd::ssh_hash_known_hosts
+  $ssh_known_hosts_timeout = $sssd::ssh_known_hosts_timeout
+
   concat::fragment { 'sssd_ssh.service':
-    target  => '/etc/sssd/sssd.conf',
+    target  => $sssd::conf_file_path,
     content => template("${module_name}/service/ssh.erb")
   }
 }

--- a/manifests/service/sudo.pp
+++ b/manifests/service/sudo.pp
@@ -6,17 +6,29 @@
 #
 # == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
-class sssd::service::sudo (
-  Optional[String]            $description        = undef,
-  Optional[Sssd::Debuglevel]  $debug_level        = undef,
-  Boolean                     $debug_timestamps   = true,
-  Boolean                     $debug_microseconds = false,
-  Boolean                     $sudo_timed         = false
-) {
+# == Parameters available to this template:
+# debug_level
+# debug_timestamps
+# debug_microseconds
+# description
+# sudo_timed
+
+class sssd::service::sudo {
+
   include '::sssd'
 
+  # These varaibles are referenced inside the autofs template, and
+  # because we don't want to worry about scope inside of the template
+  # we handle it here.
+
+  $description        = $sssd::description
+  $debug_level        = $sssd::debug_level
+  $debug_timestamps   = $sssd::debug_timestamps
+  $debug_microseconds = $sssd::debug_microseconds
+  $sudo_timed         = $sssd::sudo_timed
+
   concat::fragment { 'sssd_sudo.service':
-    target  => '/etc/sssd/sssd.conf',
+    target  => $sssd::conf_file_path,
     content => template("${module_name}/service/sudo.erb")
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,7 @@
   "source": "https://github.com/simp/pupmod-simp-sssd",
   "project_page": "https://github.com/simp/pupmod-simp-sssd",
   "issues_url": "https://simp-project.atlassian.net",
+  "data_provider": "hiera",
   "tags": [
     "simp",
     "sssd"

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -23,11 +23,11 @@ HOSTS:
     platform: el-7-x86_64
     box: centos/7
     hypervisor: vagrant
-  centos66-cli:
+  centos6-cli:
     roles:
       - client
     platform: el-6-x86_64
-    box: puppetlabs/centos-6.6-64-nocm
+    box: centos/6
     hypervisor: vagrant
 CONFIG:
   log_level: verbose

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,6 +6,15 @@ describe 'sssd' do
       context "on #{os}" do
         let(:facts){ facts }
 
+        # on RHEL / CentOS 7, owner is sssd.
+        # on RHEL / CentOS 6, owner is root. 
+        if (facts[:os][:name] == 'RedHat' || facts[:os][:name] == 'CentOS') &&
+           (facts[:os][:release][:major] > '6')
+          let(:sssd_owner){ 'sssd' }
+        else 
+          let(:sssd_owner){ 'root' }
+        end
+
         context 'with_defaults' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('sssd') }
@@ -36,7 +45,8 @@ describe 'sssd' do
           }
 
           it { is_expected.to contain_file('/etc/sssd').with({
-              :ensure  => 'directory'
+              :ensure  => 'directory',
+              :owner   => sssd_owner
             })
           }
 


### PR DESCRIPTION
(SIMP-2592)
Moved all params out of manifests and into init.pp
All default values are set in the data directory. 
data/common.yaml contains a full list of all parameters available in the module, as does init.pp
Hierarchy supports different values based on OS and version, as of now. 
Parameterized several values that used to be hard-coded.
Standardized documentation. 
SIMP-2592 #close