### PR TITLE
(SIMP-2992) Work around for broken LDAP libs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Apr 07 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.1-0
+- Worked around a bug in EL6 where the ldap client library incorrectly handles
+  128 bit ciphers in the cipher list
+
 * Fri Mar 17 2017 Clayton Mentzer, Liz Nemsick 6.0.0-1
 - Updated README
 - Update puppet version in .travis.yaml

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -12,7 +12,7 @@
 #
 # [*strip_128_bit_ciphers*]
 #   If set, on EL6 systems, all 128 bit ciphers will be removed from
-#   ``tls_cihper_suite`` prior to being written to the system.
+#   ``tls_cipher_suite`` prior to being written to the system.
 #
 #   This is due to a bug in the LDAP client libraries that will drop the SSF
 #   level to 128 when connecting over StartTLS which will be rejected by the

--- a/spec/defines/provider/ldap_spec.rb
+++ b/spec/defines/provider/ldap_spec.rb
@@ -21,6 +21,15 @@ describe 'sssd::provider::ldap' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain").without_content(%r(=\s*$)) }
+        it { is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain").without_content(%r(^\s*_.+=)) }
+
+        if ['RedHat','CentOS'].include?(facts[:os][:name])
+          if facts[:os][:release][:major] < '7'
+            it { is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain").with_content(%r(ldap_tls_cipher_suite.*-AES128)) }
+          else
+            it { is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain").without_content(%r(ldap_tls_cipher_suite.*-AES128)) }
+          end
+        end
       end
     end
   end

--- a/templates/provider/ldap.erb
+++ b/templates/provider/ldap.erb
@@ -143,7 +143,7 @@
     'ldap_chpass_uri' => ',',
     'ldap_chpass_backup_uri' => ',',
     'ldap_user_extra_attrs' => ',',
-    'ldap_tls_cipher_suite' => ':',
+    '_ldap_tls_cipher_suite' => ':',
     'ldap_access_order' => ',',
     'ldap_sudo_hostnames' => ' ',
     'ldap_sudo_ip' => ' ',
@@ -154,10 +154,9 @@
   _output = []
   _string_params.sort.each do |param|
     value = eval(%(@#{param}))
-    param.sub!(/^_/, '')
 
     if value
-      _output << %(#{param} = #{value.to_s})
+      _output << %(#{param.sub(/^_/,'')} = #{value.to_s})
     end
   end
 
@@ -165,7 +164,7 @@
     value = eval(%(@#{param}))
 
     if value && !value.empty?
-      _output << %(#{param} = #{Array(value).uniq.join(_array_params[param])})
+      _output << %(#{param.sub(/^_/,'')} = #{Array(value).uniq.join(_array_params[param])})
     end
   end
 -%>


### PR DESCRIPTION
The client LDAP libraries are broken in EL6 such that, if any 128 bit
ciphers are present in the cipher string, it will fall back to SSF=128
for connecting to an LDAP server.

This is unacceptable to the SIMP default configuration (SSF=256).

Also, fixed a bug in a template with regards to variables with prefaced
underscores.

SIMP-2992 #comment Update for SSSD