### PR TITLE
(SIMP-3016) Update Sssd::DebugLevel type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Aug 30 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.3-0
+- Sssd::DebugLevel now handles all variants specfied in sssd.conf man page
+- All instances of debug_level are now typed as Sssd::DebugLevel
+
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.2-0
 - Confine puppet version in metadata.json
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Many of the parameters and variables below have a one-to-one correspondance to t
 
 ##### `debug_level`:
   Sets the debug verbosity for the main section of the config file.
-  * Valid Options: String
+  * Valid Options: Sssd::DebugLevel
   * Default Value: undef,
 
 ##### `debug_timestamps`:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,7 +37,7 @@
 #
 class sssd (
   Array[String]                  $domains,
-  Optional[String]               $debug_level           = undef,
+  Optional[Sssd::DebugLevel]     $debug_level           = undef,
   Boolean                        $debug_timestamps      = true,
   Boolean                        $debug_microseconds    = false,
   Optional[String]               $description           = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -82,6 +82,25 @@ describe 'sssd' do
           it { is_expected.to create_class('pki') }
           it { is_expected.to create_file('/etc/pki/simp_apps/sssd/x509')}
         end
+
+        context 'with debug_level as an integer' do
+          let(:params) {{ :debug_level => 9 }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('sssd') }
+        end
+
+        context 'with debug_level as a two-byte hexidecimal' do
+          let(:params) {{ :debug_level => '0x1234' }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('sssd') }
+        end
+
+        context 'with debug_level as an invalid Sssd::DebugLevel' do
+          let(:params) {{ :debug_level => '0x123z' }}
+          it { is_expected.to compile.and_raise_error(/parameter 'debug_level' expects a value of/)}
+          let(:params) {{ :debug_level => 99 }}
+          it { is_expected.to compile.and_raise_error(/parameter 'debug_level' expects a value of/)}
+        end
       end
     end
   end

--- a/types/debuglevel.pp
+++ b/types/debuglevel.pp
@@ -1,1 +1,2 @@
-type Sssd::DebugLevel = Variant[Integer[0,9],Pattern[/^0x[01248][01248][01248]0/]]
+# Integer[0-9] or 2 byte Hexidecimal (ex. 0x0201)
+type Sssd::DebugLevel = Variant[Integer[0,9],Pattern[/0x\h{4}$/]]


### PR DESCRIPTION
- Sssd::DebugLevel now handles all variants specfied in sssd.conf man page
- All instances of debug_level are now typed as Sssd::DebugLevel

SIMP-3016 #comment ready for testing
SIMP-3696 #close
SIMP-3690 #close