### PR TITLE
(SIMP-3803) Set minimum length on sssd::domains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
 bundler_args: --without development system_tests --path .vendor
 before_install: rm Gemfile.lock || true
 script:
+  - bundle exec rake compare_latest_tag
   - bundle exec rake test
 notifications:
   email: false

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Sep 18 2017 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 6.0.4-0
+- Set minimum length on sssd::domains
+
 * Mon Sep 11 2017 Judy Johnson <judy.johnson@onyxpoint.com> - 6.0.3-0
 - Only enable 'try_inotify' if explicitly set
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd (
-  Array[String]                  $domains,
+  Array[String[1, 255], 1]       $domains,
   Optional[Sssd::DebugLevel]     $debug_level           = undef,
   Boolean                        $debug_timestamps      = true,
   Boolean                        $debug_microseconds    = false,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -55,6 +55,18 @@ describe 'sssd' do
 
         end
 
+        context 'when domains is set to the empty array' do
+          let(:params) {{ domains: [] }}
+
+          it { is_expected.to compile.and_raise_error(/parameter 'domains' expects size to be at least 1/) }
+        end
+
+        context 'when domains contains the empty string' do
+          let(:params) {{ domains: [''] }}
+
+          it { is_expected.to compile.and_raise_error(/parameter 'domains' index 0 expects a String\[1, 255\] value, got String/) }
+        end
+
         context 'try_inotify = ' do
           context 'unset' do
             it {


### PR DESCRIPTION
Prior to this commit it was possible to set the parameter `sssd::domains` to the empty array or an array containing the empty string, neither of which is allowed according to the README.  The resulting behavior in such a cases was undefined and generally erroneous.  This commit sets a minimum length on the parameter's array to 1, and requires the contained strings to be between 1 and 255 characters in accordance with RFC 2181.


SIMP-3803 #close