### PR TITLE
(SIMP-4279) sssd:  Write IPA domain code and unit test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@
     - bundle exec rake check:dot_underscore
     - bundle exec rake check:test_file
     - bundle exec rake pkg:check_version
-    - bundle exec rake compare_latest_tag
+    - bundle exec rake pkg:compare_latest_tag
     - bundle exec rake lint
     - bundle exec rake clean
     - bundle exec puppet module build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,106 +1,206 @@
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
+# https://puppet.com/docs/pe/2017.3/overview/component_versions_in_recent_pe_releases.html
+# https://puppet.com/misc/puppet-enterprise-lifecycle
+# https://puppet.com/docs/pe/2017.3/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2016.4   4.7   2.1.9  2018-10  (LTS)
+# SIMP6.0.0   4.8   2.1.9  TBD
+# PE 2017.2   4.10  2.1.9  2018-02-21
+# PE 2017.3   5.3   2.4.1  2018-07
+# PE 2018.1   ???   ?????  ????-??  (LTS)
 ---
-puppet-syntax:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
+.cache_bundler: &cache_bundler
+  cache:
+    untracked: true
+    # An attempt at caching between runs (ala Travis CI)
+    key: "${CI_PROJECT_NAMESPACE}__bundler"
+    paths:
+      - '.vendor'
+      - 'vendor'
+
+.setup_bundler_env: &setup_bundler_env
+  before_script:
+    - '(find .vendor | wc -l) || :'
+    - gem install bundler --no-rdoc --no-ri
+    - rm -f Gemfile.lock
+    - rm -rf pkg/
+    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+
+.validation_checks: &validation_checks
   script:
-    - bundle install
     - bundle exec rake syntax
-puppet-lint:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
-  script:
-    - bundle install
+    - bundle exec rake check:dot_underscore
+    - bundle exec rake check:test_file
+    - bundle exec rake pkg:check_version
+    - bundle exec rake compare_latest_tag
     - bundle exec rake lint
-puppet-metadata:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
+    - bundle exec rake clean
+    - bundle exec puppet module build
+
+.spec_tests: &spec_tests
   script:
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
-  script:
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script:
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script:
-    - bundle install
     - bundle exec rake spec
 
-# For PE LTS Support
+stages:
+  - validation
+  - unit
+  - acceptance
+  - deploy
+
+# Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax:
-  stage: test
+# --------------------------------------
+pup4.7-validation:
+  stage: validation
   tags:
     - docker
   image: ruby:2.1
-  script:
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake syntax
-unit-test-puppet4.7-ruby-2.1:
-  stage: test
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4.7-unit:
+  stage: unit
   tags:
     - docker
   image: ruby:2.1
-  script:
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.2:
-  stage: test
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 4.8 for SIMP 6.0 + 6.1 support
+# --------------------------------------
+pup4.8-validation:
+  stage: validation
   tags:
     - docker
-  image: ruby:2.2
-  allow_failure: true
-  script:
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.3:
-  stage: test
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4.8-unit:
+  stage: unit
   tags:
     - docker
-  image: ruby:2.3
-  allow_failure: true
-  script:
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
 
-<<<<<<< HEAD
-acceptance-test:
-  stage: test
+
+# Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup4.10-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4.10-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup5.3-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup5.3-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Keep an eye on the latest puppet 5
+# ----------------------------------
+pup5.latest-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+  allow_failure: true
+
+pup5.latest-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+
+# Acceptance tests
+# ==============================================================================
+acceptance-default:
+  stage: acceptance
   tags:
     - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
-    - bundle install --no-binstubs --path=vendor
-    - bundle exec rake beaker:suites
+    - bundle exec rake beaker:suites[default]
 
-acceptance-test-fips: 
-  stage: test
-  tags: 
+acceptance-fips-default:
+  stage: acceptance
+  tags:
     - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - BEAKER_fips=yes bundle exec rake beaker:suites
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake beaker:suites[default]

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ jobs:
         - bundle exec rake check:test_file
         - bundle exec rake pkg:check_version
         - bundle exec rake metadata_lint
-        - bundle exec rake compare_latest_tag
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
         - bundle exec rake lint
         - bundle exec puppet module build
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jan 19 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.0-0
+- Added sssd class option to automatically configure SSSD for an IPA
+  domain, when the host is joined to an IPA domain.
+
 * Fri Dec 15 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.0-0
 - Leveraged PR from Mark Fitch to add ima provider configuration
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
 end
 
 group :development do

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,49 @@
+#
+# Configuration class called from sssd.
+#
+# Sets up the ``[sssd]`` section of '/etc/sssd/sssd.conf', and,
+# optionally, a domain section for the IPA domain to which the host
+# is joined.  When the IPA domain is configured, the IPA domain is
+# automatically added to ``$domains`` to generate the list of domains
+# in the ``[sssd]`` section.
+#
+class sssd::config {
+  assert_private()
+  concat { '/etc/sssd/sssd.conf':
+    owner          => 'root',
+    group          => 'root',
+    mode           => '0600',
+    ensure_newline => true,
+    warn           => true,
+    notify         => Class['sssd::service']
+  }
+
+  if ($sssd::auto_add_ipa_domain and $facts['ipa']) {
+    # this host has joined an IPA domain
+    $_domains = unique(concat($::sssd::domains, $facts['ipa']['domain']))
+    include 'sssd::config::ipa_domain'
+  }
+  else {
+    $_domains = unique($::sssd::domains)
+  }
+
+  $_debug_level           = $::sssd::debug_level
+  $_debug_timestamps      = $::sssd::debug_timestamps
+  $_debug_microseconds    = $::sssd::debug_microseconds
+  $_description           = $::sssd::description
+  $_config_file_version   = $::sssd::config_file_version
+  $_services              = $::sssd::services
+  $_reconnection_retries  = $::sssd::reconnection_retries
+  $_re_expression         = $::sssd::re_expression
+  $_full_name_format      = $::sssd::full_name_format
+  $_try_inotify           = $::sssd::try_inotify
+  $_krb5_rcache_dir       = $::sssd::krb5_rcache_dir
+  $_user                  = $::sssd::user
+  $_default_domain_suffix = $::sssd::default_domain_suffix
+  $_override_space        = $::sssd::override_space
+
+  concat::fragment { 'sssd_main_config':
+    target  => '/etc/sssd/sssd.conf',
+    content => template("${module_name}/sssd.conf.erb")
+  }
+}

--- a/manifests/config/ipa_domain.pp
+++ b/manifests/config/ipa_domain.pp
@@ -1,0 +1,29 @@
+# Configures SSSD for the IPA domain to which the host has joined
+#
+class sssd::config::ipa_domain {
+  assert_private()
+  if $facts['ipa'] {
+    # this host has joined an IPA domain
+    $_ipa_domain = $facts['ipa']['domain']
+    $_ipa_server = $facts['ipa']['server']
+
+    sssd::domain { $_ipa_domain:
+      description       => "IPA Domain ${_ipa_domain}",
+      id_provider       => 'ipa',
+      auth_provider     => 'ipa',
+      chpass_provider   => 'ipa',
+      access_provider   => 'ipa',
+      sudo_provider     => 'ipa',
+      autofs_provider   => 'ipa',
+      min_id            => $::sssd::min_id,
+      enumerate         => $::sssd::enumerate_users,
+      cache_credentials => $::sssd::cache_credentials
+    }
+
+    sssd::provider::ipa { $_ipa_domain:
+      ipa_domain => $_ipa_domain,
+      ipa_server => [ $_ipa_server ]
+    }
+  }
+}
+

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -1,4 +1,4 @@
-# == Define: sssd::domain
+# Define: sssd::domain
 #
 # This define sets up a domain section of /etc/sssd.conf. This domain will be
 # named after '$name' and should be listed in your main sssd.conf if you wish
@@ -14,15 +14,58 @@
 # When you call the associated providers, you should be sure to name them based
 # on the name of this domain.
 #
-# == Parameters
+# Full documentation of the parameters that map directly to SSSD
+# configuration options can be found in the sssd.conf(5) man page.
 #
-# [*name*]
+# @param name
 #   The name of the domain.
 #   This will be placed at [domain/$name] in the configuration file.
 #
-# == Authors
+# @param id_provider
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param description
+# @param min_id
+# @param max_id
+# @param enumerate
+# @param subdomain_enumerate
+# @param force_timeout
+# @param entry_cache_timeout
+# @param entry_cache_user_timeout
+# @param entry_cache_group_timeout
+# @param entry_cache_netgroup_timeout
+# @param entry_cache_service_timeout
+# @param entry_cache_sudo_timeout
+# @param entry_cache_autofs_timeout
+# @param entry_cache_ssh_host_timeout
+# @param refresh_expired_interval
+# @param cache_credentials
+# @param account_cache_expiration
+# @param pwd_expiration_warning
+# @param use_fully_qualified_names
+# @param ignore_group_members
+# @param access_provider
+# @param auth_provider
+# @param chpass_provider
+# @param sudo_provider
+# @param selinux_provider
+# @param subdomains_provider
+# @param autofs_provider
+# @param hostid_provider
+# @param re_expression
+# @param full_name_format
+# @param lookup_family_order
+# @param dns_resolver_timeout
+# @param dns_discovery_domain
+# @param override_gid
+# @param case_sensitive
+# @param proxy_fast_alias
+# @param realmd_tags
+# @param proxy_pam_target
+# @param proxy_lib_name
 #
-# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 define sssd::domain (
   Sssd::IdProvider                           $id_provider,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,14 +4,14 @@
 #   If ``true``, install the 'sssd-tools' package for administrative
 #   changes to the SSSD databases
 #
-# @param ensure
+# @param package_ensure
 #   Ensure setting for all packages installed by this module
 #
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::install (
   Boolean  $install_user_tools = true,
-  String   $ensure             = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'latest' }),
+  String   $package_ensure     = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'latest' }),
 ) {
   contain 'sssd::install::client'
 
@@ -29,9 +29,9 @@ class sssd::install (
     require => Package['sssd']
   }
 
-  package { 'sssd': ensure => $ensure }
+  package { 'sssd': ensure => $package_ensure }
 
   if $install_user_tools {
-    package { 'sssd-tools': ensure => $ensure }
+    package { 'sssd-tools': ensure => $package_ensure }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,26 +1,21 @@
-# == Class: sssd::install
-#
 # Install the required packages for SSSD
 #
-# == Parameters:
+# @param install_user_tools
+#   If ``true``, install the 'sssd-tools' package for administrative
+#   changes to the SSSD databases
 #
-# [*install_user_tools*]
-# Type: Boolean
-# Default: true
-#   If true, install the 'sssd-tools' for administrative changes to the SSSD
-#   databases.
+# @param ensure
+#   Ensure setting for all packages installed by this module
 #
-# == Authors
-#
-# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::install (
-  Boolean  $install_user_tools = true
+  Boolean  $install_user_tools = true,
+  String   $ensure             = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'latest' }),
 ) {
-  contain '::sssd::install::client'
+  contain 'sssd::install::client'
 
-
-  if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::operatingsystemmajrelease > '6' ) {
+  if ( $facts['operatingsystem'] in ['RedHat','CentOS'] ) and ( $facts['operatingsystemmajrelease'] > '6' ) {
     $_sssd_user = 'sssd'
   } else {
     $_sssd_user = 'root'
@@ -34,16 +29,9 @@ class sssd::install (
     require => Package['sssd']
   }
 
-  file { '/etc/sssd/sssd.conf':
-    ensure => 'file',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0600'
-  }
-
-  package { 'sssd': ensure => 'latest' }
+  package { 'sssd': ensure => $ensure }
 
   if $install_user_tools {
-    package { 'sssd-tools': ensure => 'latest' }
+    package { 'sssd-tools': ensure => $ensure }
   }
 }

--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -6,7 +6,7 @@
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::install::client (
-  $ensure = $::sssd::install::ensure
+  $ensure = $::sssd::install::package_ensure
 ){
   package { 'sssd-client': ensure => $ensure }
 }

--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -1,9 +1,12 @@
-# == Class: sssd::install::client
-#
 # Install the sssd-client package
 #
+# @param ensure
+#   Ensure setting for 'sssd-client' package
+#
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
+#
 class sssd::install::client (
-  $ensure = 'latest'
+  $ensure = $::sssd::install::ensure
 ){
   package { 'sssd-client': ensure => $ensure }
 }

--- a/manifests/pki.pp
+++ b/manifests/pki.pp
@@ -1,6 +1,9 @@
-# == Class: sssd::pki
+# Class: sssd::pki
 #
-# @param pki
+# Uses the following sssd class parameters to copy certs into
+# a directory for the sssd application
+#
+# $::sssd::pki
 #   * If 'simp', include SIMP's pki module and use pki::copy to manage
 #     application certs in /etc/pki/simp_apps/sssd/x509
 #   * If true, do *not* include SIMP's pki module, but still use pki::copy
@@ -13,16 +16,11 @@
 #     * app_pki_ca
 #     * app_pki_ca_dir
 #
-# @param app_pki_external_source
-#   * If pki = 'simp' or true, this is the directory from which certs will be
+# $::ssd::app_pki_cert_source
+#   * If $::sssd::pki = 'simp' or true, this is the directory from which certs will be
 #     copied, via pki::copy.  Defaults to /etc/pki/simp/x509.
 #
-#   * If pki = false, this variable has no effect.
-#
-# @param app_pki_dir
-#   This variable controls the basepath of $app_pki_key, $app_pki_cert,
-#   $app_pki_ca, $app_pki_ca_dir, and $app_pki_crl.
-#   It defaults to /etc/pki/simp_apps/sssd/x509.
+#   * If $::sssd::pki = false, this variable has no effect.
 #
 class sssd::pki
 {

--- a/manifests/provider/ad.pp
+++ b/manifests/provider/ad.pp
@@ -28,7 +28,7 @@
 #   * Ignored if ``autodiscovery`` is enabled
 #
 # @param ad_hostname
-# @param @ad_enable_dns_sites
+# @param ad_enable_dns_sites
 #
 # @param ad_access_filters
 #   A list of access filters for the system
@@ -57,6 +57,7 @@
 #   * Has no effect if ``dyndns_update`` is not set
 #
 # @param dyndns_refresh_interval
+# @param dyndns_update_ptr
 # @param dyndns_force_tcp
 # @param dyndns_server
 # @param override_homedir
@@ -72,7 +73,7 @@
 # @param ldap_idmap_autorid_compat
 # @param ldap_idmap_helper_table_size
 #
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 define sssd::provider::ad (
   Optional[String]                                           $ad_domain                                = undef,

--- a/manifests/provider/krb5.pp
+++ b/manifests/provider/krb5.pp
@@ -1,17 +1,31 @@
-# == Define: sssd::provider::krb5
+# Define: sssd::provider::krb5
 #
 # This define sets up the 'krb5' provider section of a particular domain.
 # $name should be the name of the associated domain in sssd.conf.
 #
-# == Parameters
 # See sssd-krb5.conf(5) for additional information.
 #
-# [*name*]
+# @param name
 #   The name of the associated domain section in the configuration file.
 #
-# == Authors
+# @param krb5_server
+# @param krb5_realm
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param krb5_kpasswd
+# @param krb5_ccachedir
+# @param krb5_ccname_template
+# @param krb5_auth_timeout
+# @param krb5_validate
+# @param krb5_keytab
+# @param krb5_store_password_if_offline
+# @param krb5_renewable_lifetime
+# @param krb5_lifetime
+# @param krb5_renew_interval
+# @param krb5_use_fast
 #
-# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 define sssd::provider::krb5 (
   Simplib::Host                          $krb5_server,

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -1,16 +1,39 @@
-# == Define: sssd::provider::ldap
+# Define: sssd::provider::ldap
 #
 # This define sets up the 'ldap' provider section of a particular domain.
 # $name should be the name of the associated domain in sssd.conf.
 #
-# See sssd-ldap.conf(5) for additional information.
+# Configuration notes:
 #
-# == Parameters
+# * See sssd-ldap.conf(5) for additional information.
+# * Be careful with the following configuration:
+#     * ldap_netgroup_search_base
+#     * ldap_user_search_base
+#     * ldap_group_search_base
+#     * ldap_sudo_search_base
+#     * ldap_autofs_search_base
 #
-# [*name*]
+# * Be sure to read the man page for the following advanced
+#   configuration:
+#     * ldap_idmap_range_min
+#     * ldap_idmap_range_max
+#     * ldap_idmap_range_size
+#     * ldap_idmap_default_domain_sid
+#     * ldap_idmap_default_domain
+#     * ldap_idmap_autorid_compat
+#
+#
+# Regarding: POODLE - CVE-2014-3566
+#
+# The tls_cipher_suite variable is set to HIGH:-SSLv2 by default because
+# OpenLDAP cannot set the SSL provider natively. By default, it will run TLSv1
+# but cannot handle TLSv1.2 therefore the SSLv3 ciphers cannot be eliminated.
+# Take care to ensure that your clients only connect with TLSv1 if possible.
+#
+# @param name
 #   The name of the associated domain section in the configuration file
 #
-# [*strip_128_bit_ciphers*]
+# @param strip_128_bit_ciphers
 #   If set, on EL6 systems, all 128 bit ciphers will be removed from
 #   ``tls_cipher_suite`` prior to being written to the system.
 #
@@ -20,18 +43,156 @@
 #
 #   This has no effect on EL7+ systems.
 #
-# == Notes
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param ldap_uri
+# @param ldap_backup_uri
+# @param ldap_chpass_uri
+# @param ldap_chpass_backup_uri
+# @param ldap_chpass_update_last_change
+# @param ldap_search_base
+# @param ldap_schema
+# @param ldap_default_bind_dn
+# @param ldap_default_authtok_type
+# @param ldap_default_authtok
+# @param ldap_user_object_class
+# @param ldap_user_name
+# @param ldap_user_uid_number
+# @param ldap_user_gid_number
+# @param ldap_user_gecos
+# @param ldap_user_home_directory
+# @param ldap_user_shell
+# @param ldap_user_uuid
+# @param ldap_user_objectsid
+# @param ldap_user_modify_timestamp
+# @param ldap_user_shadow_last_change
+# @param ldap_user_shadow_min
+# @param ldap_user_shadow_max
+# @param ldap_user_shadow_warning
+# @param ldap_user_shadow_inactive
+# @param ldap_user_shadow_expire
+# @param ldap_user_krb_last_pwd_change
+# @param ldap_user_krb_password_expiration
+# @param ldap_user_ad_account_expires
+# @param ldap_user_ad_user_account_control
+# @param ldap_ns_account_lock
+# @param ldap_user_nds_login_disabled
+# @param ldap_user_nds_login_expiration_time
+# @param ldap_user_nds_login_allowed_time_map
+# @param ldap_user_principal
+# @param ldap_user_extra_attrs
+# @param ldap_user_ssh_public_key
+# @param ldap_force_upper_case_realm
+# @param ldap_enumeration_refresh_timeout
+# @param ldap_purge_cache_timeout
+# @param ldap_user_fullname
+# @param ldap_user_member_of
+# @param ldap_user_authorized_service
+# @param ldap_user_authorized_host
+# @param ldap_group_object_class
+# @param ldap_group_name
+# @param ldap_group_gid_number
+# @param ldap_group_member
+# @param ldap_group_uuid
+# @param ldap_group_objectsid
+# @param ldap_group_modify_timestamp
+# @param ldap_group_type
+# @param ldap_group_nesting_level
+# @param ldap_groups_use_matching_rule_in_chain
+# @param ldap_initgroups_use_matching_rule_in_chain
+# @param ldap_use_tokengroups
+# @param ldap_netgroup_object_class
+# @param ldap_netgroup_name
+# @param ldap_netgroup_member
+# @param ldap_netgroup_triple
+# @param ldap_netgroup_uuid
+# @param ldap_netgroup_modify_timestamp
+# @param ldap_service_name
+# @param ldap_service_port
+# @param ldap_service_proto
+# @param ldap_service_search_base
+# @param ldap_search_timeout
+# @param ldap_enumeration_search_timeout
+# @param ldap_network_timeout
+# @param ldap_opt_timeout
+# @param ldap_connection_expire_timeout
+# @param ldap_page_size
+# @param ldap_disable_paging
+# @param ldap_disable_range_retrieval
+# @param ldap_sasl_minssf
+# @param ldap_deref_threshold
+# @param ldap_tls_reqcert
+# @param app_pki_ca_dir
+# @param app_pki_key
+# @param app_pki_cert
+# @param strip_128_bit_ciphers
+# @param ldap_tls_cipher_suite
+# @param ldap_id_use_start_tls
+# @param ldap_id_mapping
+# @param ldap_min_id
+# @param ldap_max_id
+# @param ldap_sasl_mech
+# @param ldap_sasl_authid
+# @param ldap_sasl_realm
+# @param ldap_sasl_canonicalize
+# @param ldap_krb5_keytab
+# @param ldap_krb5_init_creds
+# @param ldap_krb5_ticket_lifetime
+# @param krb5_server
+# @param krb5_backup_server
+# @param krb5_realm
+# @param krb5_canonicalize
+# @param krb5_use_kdcinfo
+# @param ldap_pwd_policy
+# @param ldap_referrals
+# @param ldap_dns_service_name
+# @param ldap_chpass_dns_service_name
+# @param ldap_access_filter
+# @param ldap_account_expire_policy
+# @param ldap_access_order
+# @param ldap_pwdlockout_dn
+# @param ldap_deref
+# @param ldap_sudorule_object_class
+# @param ldap_sudorule_name
+# @param ldap_sudorule_command
+# @param ldap_sudorule_host
+# @param ldap_sudorule_user
+# @param ldap_sudorule_option
+# @param ldap_sudorule_runasuser
+# @param ldap_sudorule_runasgroup
+# @param ldap_sudorule_notbefore
+# @param ldap_sudorule_notafter
+# @param ldap_sudorule_order
+# @param ldap_sudo_full_refresh_interval
+# @param ldap_sudo_smart_refresh_interval
+# @param ldap_sudo_use_host_filter
+# @param ldap_sudo_hostnames
+# @param ldap_sudo_ip
+# @param ldap_sudo_include_netgroups
+# @param ldap_sudo_include_regexp
+# @param ldap_autofs_map_master_name
+# @param ldap_autofs_map_object_class
+# @param ldap_autofs_map_name
+# @param ldap_autofs_entry_object_class
+# @param ldap_autofs_entry_key
+# @param ldap_autofs_entry_value
+# @param ldap_netgroup_search_base
+# @param ldap_user_search_base
+# @param ldap_group_search_base
+# @param ldap_sudo_search_base
+# @param ldap_autofs_search_base
 #
-# Regarding: POODLE - CVE-2014-3566
+# Advanced Configuration - Read the man page
 #
-# The tls_cipher_suite variable is set to HIGH:-SSLv2 by default because
-# OpenLDAP cannot set the SSL provider natively. By default, it will run TLSv1
-# but cannot handle TLSv1.2 therefore the SSLv3 ciphers cannot be eliminated.
-# Take care to ensure that your clients only connect with TLSv1 if possible.
+# @param ldap_idmap_range_min
+# @param ldap_idmap_range_max
+# @param ldap_idmap_range_size
+# @param ldap_idmap_default_domain_sid
+# @param ldap_idmap_default_domain
+# @param ldap_idmap_autorid_compat
 #
-# == Authors
-#
-# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 define sssd::provider::ldap (
   Optional[Sssd::DebugLevel]            $debug_level                       = undef,

--- a/manifests/provider/local.pp
+++ b/manifests/provider/local.pp
@@ -1,17 +1,26 @@
-# == Define: sssd::provider::local
+# Define: sssd::provider::local
 #
 # This define sets up the 'local' id_provider section of a particular domain.
 # $name should be the name of the associated domain in sssd.conf.
 #
-# == Parameters
 # See 'The local domain section' in sssd.conf(5) for additional information.
 #
-# [*name*]
+# @param name
 #   The name of the associated domain section in the configuration file.
 #
-# == Authors
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param default_shell
+# @param base_directory
+# @param create_homedir
+# @param remove_homedir
+# @param homedir_umask
+# @param skel_dir
+# @param mail_dir
+# @param userdel_cmd
 #
-# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 define sssd::provider::local (
   Optional[Sssd::DebugLevel]      $debug_level        = undef,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,7 @@
 # == Class: sssd::service
-#
 # Control the SSSD services
 #
-# == Authors
-#
-# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::service {
 

--- a/manifests/service/autofs.pp
+++ b/manifests/service/autofs.pp
@@ -1,10 +1,16 @@
-# == Class: sssd::service::autofs
-#
 # This class sets up the [autofs] section of /etc/sssd.conf.
 #
-# == Authors
+# The class parameters map directly to SSSD configuration.  Full
+# documentation of these configuration options can be found in the
+# sssd.conf(5) man page.
 #
-# == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @param description
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param autofs_negative_timeout
+#
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::service::autofs (
   Optional[String]            $description              = undef,

--- a/manifests/service/nss.pp
+++ b/manifests/service/nss.pp
@@ -1,11 +1,33 @@
-# == Class: sssd::service::nss
-#
 # This class sets up the [nss] section of /etc/sssd.conf.
 # You may only have one of these per system.
 #
-# == Authors
+# The class parameters map directly to SSSD configuration.  Full
+# documentation of these configuration options can be found in the
+# sssd.conf(5) man page.
 #
-# * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @param description
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param reconnection_retries
+# @param fd_limit
+# @param command
+# @param enum_cache_timeout
+# @param entry_cache_nowait_percentage
+# @param entry_negative_timeout
+# @param filter_users
+# @param filter_groups
+# @param filter_users_in_groups
+# @param override_homedir
+# @param fallback_homedir
+# @param override_shell
+# @param vetoed_shells
+# @param default_shell
+# @param get_domains_timeout
+# @param memcache_timeout
+# @param user_attributes
+#
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::service::nss (
   Optional[String]             $description                   = undef,

--- a/manifests/service/pac.pp
+++ b/manifests/service/pac.pp
@@ -1,10 +1,16 @@
-# == Class: sssd::service::pac
-#
 # This class sets up the [pac] section of /etc/sssd.conf.
 #
-# == Authors
+# The class parameters map directly to SSSD configuration.  Full
+# documentation of these configuration options can be found in the
+# sssd.conf(5) man page.
 #
-# == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @param description
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param allowed_uids
+#
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::service::pac (
   Optional[String]             $description        = undef,

--- a/manifests/service/pam.pp
+++ b/manifests/service/pam.pp
@@ -1,11 +1,27 @@
-# == Class: sssd::service::pam
-#
 # This class sets up the [pam] section of /etc/sssd.conf.
 # You may only have one of these per system.
 #
-# == Authors
+# The class parameters map directly to SSSD configuration.  Full
+# documentation of these configuration options can be found in the
+# sssd.conf(5) man page.
 #
-# == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @param description
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param reconnection_retries
+# @param command
+# @param offline_credentials_expiration
+# @param offline_failed_login_attempts
+# @param offline_failed_login_delay
+# @param pam_verbosity
+# @param pam_id_timeout
+# @param pam_pwd_expiration_warning
+# @param get_domains_timeout
+# @param pam_trusted_users
+# @param pam_public_domains
+#
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::service::pam (
   Optional[String]             $description                    = undef,

--- a/manifests/service/ssh.pp
+++ b/manifests/service/ssh.pp
@@ -1,10 +1,17 @@
-# == Class: sssd::service::ssh
-#
 # This class sets up the [ssh] section of /etc/sssd.conf.
 #
-# == Authors
+# The class parameters map directly to SSSD configuration.  Full
+# documentation of these configuration options can be found in the
+# sssd.conf(5) man page.
 #
-# == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @param description
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param ssh_hash_known_hosts
+# @param ssh_known_hosts_timeout
+#
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::service::ssh (
   Optional[String]             $description             = undef,

--- a/manifests/service/sudo.pp
+++ b/manifests/service/sudo.pp
@@ -1,10 +1,16 @@
-# == Class: sssd::service::sudo
-#
 # This class sets up the [sudo] section of /etc/sssd.conf.
 #
-# == Authors
+# The class parameters map directly to SSSD configuration.  Full
+# documentation of these configuration options can be found in the
+# sssd.conf(5) man page.
 #
-# == Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @param description
+# @param debug_level
+# @param debug_timestamps
+# @param debug_microseconds
+# @param sudo_timed
+#
+# @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::service::sudo (
   Optional[String]            $description        = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.10.0 < 4.0.0"
+      "version_requirement": ">= 3.9.0 < 4.0.0"
     },
     {
       "name": "simp/simp_options",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -23,11 +23,11 @@ HOSTS:
     platform: el-7-x86_64
     box: centos/7
     hypervisor: vagrant
-  centos66-cli:
+  centos6-cli:
     roles:
       - client
     platform: el-6-x86_64
-    box: puppetlabs/centos-6.6-64-nocm
+    box: centos/6
     hypervisor: vagrant
 CONFIG:
   log_level: verbose

--- a/spec/classes/config/ipa_domain_spec.rb
+++ b/spec/classes/config/ipa_domain_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+shared_examples_for 'a sssd::config::ipa_domain' do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_class('sssd::config::ipa_domain') }
+  it { is_expected.to contain_sssd__domain('ipa.example.com').with({
+      :description       => 'IPA Domain ipa.example.com',
+      :id_provider       => 'ipa',
+      :auth_provider     => 'ipa',
+      :chpass_provider   => 'ipa',
+      :access_provider   => 'ipa',
+      :sudo_provider     => 'ipa',
+      :autofs_provider   => 'ipa',
+      :min_id            => 500,
+      :enumerate         => false,
+      :cache_credentials => true
+    })
+  }
+
+  it { is_expected.to contain_sssd__provider__ipa('ipa.example.com').with({
+      :ipa_domain => 'ipa.example.com',
+      :ipa_server => [ 'ipaserver.example.com' ]
+    })
+  }
+end
+
+# We have to test sssd::config::ipa_config via sssd, because
+# sssd::config:ipa_config is private.  To take advantage of hooks built
+# into puppet-rspec, the class described needs to be the class
+# instantiated, i.e., sssd.
+describe 'sssd' do
+  let(:ipa_fact_joined) {
+    {
+      :ipa => {
+        :domain => 'ipa.example.com',
+        :server => 'ipaserver.example.com',
+      }
+    }
+  }
+
+  context 'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        context 'when joined to an IPA domain' do
+          let(:facts) { os_facts.merge(ipa_fact_joined) }
+          let(:params) {{ :domains => ['ipa.example.com'] }}
+
+          it_should_behave_like 'a sssd::config::ipa_domain'
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+
+default_content  = <<EOM
+[sssd]
+domains = LOCAL,LDAP
+services = nss,pam,ssh,sudo
+config_file_version = 2
+reconnection_retries = 3
+debug_timestamps = true
+debug_microseconds = false
+EOM
+
+default_content_with_ipa_domain = default_content.gsub(/LOCAL,LDAP/,'LOCAL,LDAP,ipa.example.com')
+
+default_content_plus_optional = <<EOM
+[sssd]
+description = sssd section description
+domains = LOCAL,LDAP
+services = nss,pam,ssh,sudo
+config_file_version = 2
+reconnection_retries = 3
+re_expression = (.+)@(.+)
+full_name_format =  %1$s@%2$s
+try_inotify = true
+krb5_rcache_dir = __LIBKRB5_DEFAULTS__
+user = sssduser
+default_domain_suffix = example.com
+override_space = __
+debug_level = 3
+debug_timestamps = true
+debug_microseconds = false
+EOM
+
+shared_examples_for 'a sssd::config' do |content|
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_class('sssd::config') }
+  it { is_expected.to contain_concat('/etc/sssd/sssd.conf').with({
+      :owner          => 'root',
+      :group          => 'root',
+      :mode           => '0600',
+      :ensure_newline => true,
+      :warn           => true,
+      :notify         => 'Class[Sssd::Service]'
+    })
+  }
+
+  it { is_expected.to contain_concat__fragment('sssd_main_config').with({
+      :target  => '/etc/sssd/sssd.conf',
+      :content => content
+    })
+  }
+end
+
+# We have to test sssd::config via sssd, because sssd::config is
+# private.  To take advantage of hooks built into puppet-rspec, the
+# class described needs to be the class instantiated, i.e., sssd.
+describe 'sssd' do
+  let(:sssd_domains) { ['LOCAL', 'LDAP'] }
+  let(:ipa_fact_joined) {
+    {
+      :ipa => {
+        :domain => 'ipa.example.com',
+        :server => 'ipaserver.example.com',
+      }
+    }
+  }
+
+  context 'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+
+        context 'with default parameters used by sssd::config' do
+          let(:params) {{ :domains => sssd_domains }}
+
+          context 'when not joined to an IPA domain' do
+            let(:facts) { os_facts }
+
+            it_should_behave_like 'a sssd::config', default_content
+            it { is_expected.to_not contain_class('sssd::config::ipa_domain') }
+          end
+
+          context 'when joined to an IPA domain' do
+            let(:facts) { os_facts.merge( ipa_fact_joined ) }
+
+            it_should_behave_like 'a sssd::config', default_content_with_ipa_domain
+            it { is_expected.to contain_class('sssd::config::ipa_domain') }
+          end
+        end
+
+        context 'with all optional sssd config parameters specified' do
+          let(:facts){ os_facts }
+          let(:params) { {
+            :domains               => sssd_domains,
+            :debug_level           => 3,
+            :description           => 'sssd section description',
+            :re_expression         => '(.+)@(.+)',
+            :full_name_format      => ' %1$s@%2$s',
+            :try_inotify           =>  true,
+            :krb5_rcache_dir       =>  '__LIBKRB5_DEFAULTS__',
+            :user                  =>  'sssduser',
+            :default_domain_suffix =>  'example.com',
+            :override_space        =>  '__',
+          } }
+
+          it_should_behave_like 'a sssd::config', default_content_plus_optional
+        end
+
+        context 'when $::sssd::auto_add_ip_domain is false' do
+          let(:params) { {
+            :domains => sssd_domains,
+            :auto_add_ipa_domain => false
+          } }
+
+          context 'when not joined to an IPA domain' do
+            let(:facts){ os_facts }
+
+            it_should_behave_like 'a sssd::config', default_content
+            it { is_expected.to_not contain_class('sssd::config::ipa_domain') }
+          end
+
+          context 'when joined to an IPA domain' do
+            let(:facts) { os_facts.merge( ipa_fact_joined ) }
+
+            it_should_behave_like 'a sssd::config', default_content
+            it { is_expected.to_not contain_class('sssd::config::ipa_domain') }
+          end
+
+        end
+
+        context 'when $::sssd::domains has duplicate entries' do
+          let(:params) {{ :domains => sssd_domains + sssd_domains }}
+
+          # this verifies domain list is deduped in content
+          it_should_behave_like 'a sssd::config', default_content
+          it { is_expected.to_not contain_class('sssd::config::ipa_domain') }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,57 +2,20 @@ require 'spec_helper'
 
 describe 'sssd' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts){ facts }
+        let(:facts){ os_facts }
 
         context 'with_defaults' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('sssd') }
-          it { is_expected.to create_class('sssd::install').that_notifies('Class[sssd::service]') }
+          it { is_expected.to create_class('sssd::install').that_comes_before('Class[sssd::config]') }
+          it { is_expected.to create_class('sssd::config').that_notifies('Class[sssd::service]') }
           it { is_expected.to create_class('sssd::service') }
-          it { is_expected.to_not create_class('sssd::pki') }
-          it { is_expected.to_not contain_class('pki') }
-          it { is_expected.to_not create_pki__copy('/etc/pki/sssd') }
-          it { is_expected.to_not create_file('/etc/pki/simp_apps/sssd/x509')}
           it { is_expected.to_not create_class('auditd') }
-
-          it { is_expected.to contain_concat('/etc/sssd/sssd.conf').with({
-            :notify => 'Class[Sssd::Service]'
-            })
-          }
-
-          it { is_expected.to contain_concat__fragment('sssd_main_config').with({
-              :target  => '/etc/sssd/sssd.conf',
-              :content => /\[sssd\]/
-            })
-          }
-
-          it { is_expected.to contain_file('/etc/init.d/sssd').with({
-            :ensure  => 'file',
-            :source  => 'puppet:///modules/sssd/sssd.sysinit',
-            :notify  => 'Service[sssd]'
-            })
-          }
-
-          it { is_expected.to contain_file('/etc/sssd').with({
-              :ensure  => 'directory'
-            })
-          }
-
-          it { is_expected.to contain_package('sssd').with_ensure('latest') }
-          it { is_expected.to contain_service('nscd').with({
-              :ensure => 'stopped',
-              :enable => false,
-              :notify => 'Service[sssd]'
-            })
-          }
-
-          it { is_expected.to contain_service('sssd').with({
-              :ensure    => 'running'
-            })
-          }
-
+          it { is_expected.to_not create_audit__rule('sssd') }
+          it { is_expected.to_not create_class('sssd::pki') }
+          it { is_expected.to_not create_pki__copy('sssd') }
         end
 
         context 'when domains is set to the empty array' do
@@ -67,60 +30,35 @@ describe 'sssd' do
           it { is_expected.to compile.and_raise_error(/parameter 'domains' index 0 expects a String\[1, 255\] value, got String/) }
         end
 
-        context 'try_inotify = ' do
-          context 'unset' do
-            it {
-              is_expected.to contain_concat__fragment('sssd_main_config')
-
-              is_expected.to_not contain_concat__fragment('sssd_main_config').
-                with_content(/try_inotify/)
-            }
-          end
-          context 'true' do
-            let(:params) {{ :try_inotify => true }}
-
-            it {
-              is_expected.to contain_concat__fragment('sssd_main_config').
-                with_content(/try_inotify = true/)
-            }
-          end
-
-          context 'false' do
-            let(:params) {{ :try_inotify => false }}
-
-            it {
-              is_expected.to contain_concat__fragment('sssd_main_config').
-                with_content(/try_inotify = false/)
-            }
-          end
-        end
-
-        context 'with_auditd = true' do
+        context 'with auditd = true' do
           let(:params) {{ :auditd => true }}
 
           it { is_expected.to create_class('auditd')}
           it { is_expected.to create_auditd__rule('sssd').with({
-            :content => '-w /etc/sssd/ -p wa -k CFG_sssd' }) }
+            :content => '-w /etc/sssd/ -p wa -k CFG_sssd' })
+          }
         end
 
         context 'with pki = true' do
-          let(:params) {{ :pki      => true}}
+          let(:params) {{ :pki => true}}
 
           it { is_expected.to create_class('sssd::pki') }
           it { is_expected.to create_pki__copy('sssd').with({
-            :source => '/etc/pki/simp/x509' }) }
-          it { is_expected.to_not create_class('pki')}
-          it { is_expected.to create_file('/etc/pki/simp_apps/sssd/x509')}
+              :source => '/etc/pki/simp/x509',
+              :pki    => true
+            })
+          }
         end
 
         context 'with pki = simp' do
-          let(:params) {{ :pki     => 'simp'}}
+          let(:params) {{ :pki => 'simp'}}
 
           it { is_expected.to create_class('sssd::pki') }
           it { is_expected.to create_pki__copy('sssd').with({
-            :source => '/etc/pki/simp/x509' }) }
-          it { is_expected.to create_class('pki') }
-          it { is_expected.to create_file('/etc/pki/simp_apps/sssd/x509')}
+              :source => '/etc/pki/simp/x509',
+              :pki    => 'simp'
+            })
+          }
         end
 
         context 'with debug_level as an integer' do

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'sssd::install' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        let(:facts){ os_facts }
+
+        context 'with_defaults' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('sssd::install') }
+          it { is_expected.to create_class('sssd::install::client') }
+          it {
+            if facts[:operatingsystemmajrelease] > '6'
+              is_expected.to contain_file('/etc/sssd').with({
+                :ensure  => 'directory',
+                :owner   => 'sssd',
+                :group   => 'root',
+                :mode   => '0640',
+                :require   => 'Package[sssd]',
+              })
+            else
+              is_expected.to contain_file('/etc/sssd').with({
+                :ensure  => 'directory',
+                :owner   => 'root',
+                :group   => 'root',
+                :mode   => '0640',
+                :require   => 'Package[sssd]',
+              })
+            end
+          }
+
+          it { is_expected.to contain_package('sssd').with_ensure('latest') }
+          it { is_expected.to contain_package('sssd-tools').with_ensure('latest') }
+          it { is_expected.to contain_package('sssd-client').with_ensure('latest') }
+        end
+
+        context 'when install_user_tools = false' do
+          let(:params) {{ :install_user_tools => false }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('sssd').with_ensure('latest') }
+          it { is_expected.to_not contain_package('sssd-tools').with_ensure('latest') }
+          it { is_expected.to contain_package('sssd-client').with_ensure('latest') }
+        end
+
+        context 'when ensure = installed' do
+          let(:params) {{ :ensure =>  'installed' }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('sssd').with_ensure('installed') }
+          it { is_expected.to contain_package('sssd-tools').with_ensure('installed') }
+          it { is_expected.to contain_package('sssd-client').with_ensure('installed') }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -44,8 +44,8 @@ describe 'sssd::install' do
           it { is_expected.to contain_package('sssd-client').with_ensure('latest') }
         end
 
-        context 'when ensure = installed' do
-          let(:params) {{ :ensure =>  'installed' }}
+        context 'when package_ensure = installed' do
+          let(:params) {{ :package_ensure =>  'installed' }}
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_package('sssd').with_ensure('installed') }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'sssd::service' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        let(:os_facts){ facts }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('sssd::service') }
+          it { is_expected.to contain_file('/etc/init.d/sssd').with({
+            :ensure  => 'file',
+            :source  => 'puppet:///modules/sssd/sssd.sysinit',
+            :notify  => 'Service[sssd]'
+            })
+          }
+
+          it { is_expected.to contain_service('nscd').with({
+              :ensure => 'stopped',
+              :enable => false,
+              :notify => 'Service[sssd]'
+            })
+          }
+
+          it { is_expected.to contain_service('sssd').with({
+              :ensure => 'running',
+              :enable => true
+            })
+          }
+      end
+    end
+  end
+end

--- a/templates/sssd.conf.erb
+++ b/templates/sssd.conf.erb
@@ -1,34 +1,34 @@
 [sssd]
-<% if @debug_level -%>
-debug_level = <%= @debug_level %>
+<% if @_description -%>
+description = <%= @_description %>
 <% end -%>
-debug_timestamps = <%= @debug_timestamps.to_s %>
-debug_microseconds = <%= @debug_microseconds.to_s %>
-<% if @description -%>
-description = <%= @description %>
+domains = <%= Array(@_domains).join(',') %>
+services = <%= Array(@_services).join(',') %>
+config_file_version = <%= @_config_file_version.to_s %>
+reconnection_retries = <%= @_reconnection_retries.to_s %>
+<% if @_re_expression -%>
+re_expression = <%= @_re_expression %>
 <% end -%>
-domains = <%= Array(@domains).join(',') %>
-config_file_version = <%= @config_file_version.to_s %>
-services = <%= Array(@services).join(',') %>
-reconnection_retries = <%= @reconnection_retries.to_s %>
-<% if @re_expression -%>
-re_expression = <%= @re_expression %>
+<% if @_full_name_format -%>
+full_name_format = <%= @_full_name_format %>
 <% end -%>
-<% if @full_name_format -%>
-full_name_format = <%= @full_name_format %>
+<% unless @_try_inotify.nil? -%>
+try_inotify = <%= @_try_inotify.to_s %>
 <% end -%>
-<% unless @try_inotify.nil? -%>
-try_inotify = <%= @try_inotify.to_s %>
+<% if @_krb5_rcache_dir -%>
+krb5_rcache_dir = <%= @_krb5_rcache_dir %>
 <% end -%>
-<% if @krb5_rcache_dir -%>
-krb5_rcache_dir = <%= @krb5_rcache_dir %>
+<% if @_user -%>
+user = <%= @_user %>
 <% end -%>
-<% if @user -%>
-user = <%= @user %>
+<% if @_default_domain_suffix -%>
+default_domain_suffix = <%= @_default_domain_suffix %>
 <% end -%>
-<% if @default_domain_suffix -%>
-default_domain_suffix = <%= @default_domain_suffix %>
+<% if @_override_space-%>
+override_space = <%= @_override_space%>
 <% end -%>
-<% if @override_space-%>
-override_space = <%= @override_space%>
+<% unless @_debug_level.nil? -%>
+debug_level = <%= @_debug_level %>
 <% end -%>
+debug_timestamps = <%= @_debug_timestamps.to_s %>
+debug_microseconds = <%= @_debug_microseconds.to_s %>


### PR DESCRIPTION
- Added sssd class option to automatically configure SSSD for an IPA
  domain, when the host is joined to an IPA domain.
- Use simp_options::package_ensure in install classes
- Added unit tests
- Cleaned up some puppet strings warnings
- Tweaked module documentation

NOTE:  Manual testing of this on a SIMP server/client that
is joined to an IPA domain requires
https://github.com/simp/pupmod-simp-simplib/pull/133 changes to
simplib/lib/facter/ipa.rb.

SIMP-4279 #close