### PR TITLE
Allow passing ldap_tls_cacert to sssd::provider::ldap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Mar 14 2018 Philippe Muller <pmuller@users.github.com> - 6.1.0-0
+* Wed Mar 14 2018 Philippe Muller <philippe.muller@gmail.com> - 6.1.0-0
 - Allow passing ldap_tls_cacert to sssd::provider::ldap
 
 * Wed Feb 28 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Mar 14 2018 Philippe Muller <pmuller@users.github.com> - 6.1.0-0
+- Allow passing ldap_tls_cacert to sssd::provider::ldap
+
 * Wed Feb 28 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
 - Some template and concat changes to make debugging the module easier
   - Add headers to more easily diagnose where to stick params

--- a/README.md
+++ b/README.md
@@ -1351,6 +1351,7 @@ Defaults for these variables can be found in the sssd::provider::ldap manifest
 ##### `ldap_sasl_minssf`
 ##### `ldap_deref_threshold`
 ##### `ldap_tls_reqcert`
+##### `ldap_tls_cacert`
 ##### `app_pki_ca_dir`
 ##### `app_pki_key`
 ##### `app_pki_cert`

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -123,6 +123,7 @@
 # @param ldap_sasl_minssf
 # @param ldap_deref_threshold
 # @param ldap_tls_reqcert
+# @param ldap_tls_cacert
 # @param app_pki_ca_dir
 # @param app_pki_key
 # @param app_pki_cert
@@ -275,6 +276,7 @@ define sssd::provider::ldap (
   Optional[Integer]                     $ldap_sasl_minssf                  = undef,
   Optional[Integer[0]]                  $ldap_deref_threshold              = undef,
   Sssd::LdapTlsReqcert                  $ldap_tls_reqcert                  = 'demand',
+  Optional[String]                      $ldap_tls_cacert                   = undef,
   Optional[Stdlib::Absolutepath]        $app_pki_ca_dir                    = undef,
   Optional[Stdlib::Absolutepath]        $app_pki_key                       = undef,
   Optional[Stdlib::Absolutepath]        $app_pki_cert                      = undef,

--- a/spec/defines/provider/ldap_spec.rb
+++ b/spec/defines/provider/ldap_spec.rb
@@ -22,6 +22,7 @@ describe 'sssd::provider::ldap' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain").without_content(%r(=\s*$)) }
         it { is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain").without_content(%r(^\s*_.+=)) }
+        it { is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain").without_content('ldap_tls_cacert = ') }
 
         if ['RedHat','CentOS'].include?(facts[:os][:name])
           if facts[:os][:release][:major] < '7'
@@ -29,6 +30,25 @@ describe 'sssd::provider::ldap' do
           else
             it { is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain").without_content(%r(ldap_tls_cipher_suite.*-AES128)) }
           end
+        end
+      end
+    end
+  end
+end
+
+describe 'sssd::provider::ldap' do
+  context 'ldap_tls_cacert' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+        let(:title) {'test_ldap_provider'}
+        let(:precondition) { 'include ::sssd' }
+        let(:params) {{ :ldap_tls_cacert => '/path/to/cacert.pem' }}
+
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to create_concat__fragment("sssd_#{title}_ldap_provider.domain")
+            .with_content(%r(ldap_tls_cacert = /path/to/cacert.pem\n))
         end
       end
     end


### PR DESCRIPTION
This is helpful to ease adoption of this module in pre-existing systems,
without adding a dependency on simp-pki right away.

The parameter was already handled by the related template.