### PR TITLE
(SIMP-4577) Wrong version of puppet-agent installed in tests

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -11,6 +11,11 @@ include BeakerWindows::Powershell
 include BeakerWindows::Registry
 include BeakerWindows::WindowsFeature
 
+if ENV['PUPPET_VERSION']
+  # have to tell run_puppet_install_helper the version of
+  # puppet-agent that corresponds to PUPPET_VERSION
+  ENV['PUPPET_INSTALL_VERSION'] = latest_puppet_agent_version_for(ENV['PUPPET_VERSION'])
+end
 run_puppet_install_helper
 
 hosts.each do |host|


### PR DESCRIPTION
PUPPET_VERSION was erroneously being used for the puppet-agent version.  This is because this components spec_helper_acceptance.rb is different from most components.
SIMP-4577 #close