### PR TITLE
(SIMP-4949) Add ldap values to ad provider

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,6 +195,7 @@ default:
   <<: *cache_bundler
   <<: *setup_bundler_env
   script:
+    - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]
 
 fips-default:
@@ -206,6 +207,7 @@ fips-default:
   variables:
     BEAKER_fips: 'yes'
   script:
+    - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]
 
 ad:
@@ -215,4 +217,5 @@ ad:
   <<: *cache_bundler
   <<: *setup_bundler_env
   script:
+    - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[ad]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jun 01 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.1.2-0
+- Added ldap_use_tokengroups, ldap_group_objectsid, ldap_user_objectsid to sssd::provider::ad
+- Updated required version of puppetlabs-stdlib to 4.19.0 since fact function is used
+
 * Wed Mar 28 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.1-0
 - sssd::provider::ad::ldap_schema should be a string, not a boolean
 - AD test cleanup

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Jun 29 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.1.2-0
+* Fri Jul 13 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.1.3-0
 - Added ldap_use_tokengroups, ldap_group_objectsid, ldap_user_objectsid to sssd::provider::ad
 - Updated required version of puppetlabs-stdlib to 4.19.0 since fact function is used
 

--- a/manifests/provider/ad.pp
+++ b/manifests/provider/ad.pp
@@ -77,6 +77,9 @@
 # @param ldap_idmap_default_domain
 # @param ldap_idmap_autorid_compat
 # @param ldap_idmap_helper_table_size
+# @param ldap_use_tokengroups
+# @param ldap_group_objectsid
+# @param ldap_user_objectsid
 #
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
@@ -125,7 +128,10 @@ define sssd::provider::ad (
   Optional[String]                                           $ldap_idmap_default_domain_sid            = undef,
   Optional[String]                                           $ldap_idmap_default_domain                = undef,
   Optional[Boolean]                                          $ldap_idmap_autorid_compat                = undef,
-  Optional[Integer[1]]                                       $ldap_idmap_helper_table_size             = undef
+  Optional[Integer[1]]                                       $ldap_idmap_helper_table_size             = undef,
+  Boolean                                                    $ldap_use_tokengroups                     = true,
+  Optional[String]                                           $ldap_group_objectsid                     = undef,
+  Optional[String]                                           $ldap_user_objectsid                      = undef,
 ) {
   include '::sssd'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.19.0 < 5.0.0"
     },
     {
       "name": "simp/simpcat",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/ad/files/sssd.conf.txt
+++ b/spec/acceptance/suites/ad/files/sssd.conf.txt
@@ -103,3 +103,4 @@ krb5_realm = TEST.CASE
 krb5_store_password_if_offline = true
 ldap_id_mapping = true
 ldap_schema = ad
+ldap_use_tokengroups = true

--- a/spec/acceptance/suites/default/files/sssd.conf.txt
+++ b/spec/acceptance/suites/default/files/sssd.conf.txt
@@ -149,3 +149,4 @@ fallback_homedir = /home/%u@%d
 krb5_realm = TEST.CASE
 krb5_store_password_if_offline = true
 ldap_id_mapping = false
+ldap_use_tokengroups = true

--- a/templates/provider/ad.erb
+++ b/templates/provider/ad.erb
@@ -135,3 +135,10 @@ ldap_idmap_autorid_compat = <%= @ldap_idmap_autorid_compat %>
 ldap_idmap_helper_table_size = <%= @ldap_idmap_helper_table_size %>
 <%   end -%>
 <% end -%>
+ldap_use_tokengroups = <%= @ldap_use_tokengroups %>
+<% if @ldap_group_objectsid -%>
+ldap_group_objectsid = <%= @ldap_group_objectsid %>
+<% end -%>
+<% if @ldap_user_objectsid -%>
+ldap_user_objectsid = <%= @ldap_user_objectsid %>
+<% end -%>


### PR DESCRIPTION
This change adds the following settings to the ad provider
- ldap_use_tokengroups
- ldap_group_objectsid
- ldap_user_objectsid

These settings are supported for SSSD as of version 1.12.4 and are required
to satisfy some lookup issues when connecting to AD.

Closes SIMP-4949