### PR TITLE
(SIMP-4652) sssd: Unmangle /etc/sssd perms

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Tue Jun 19 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.2-0
+- Avoid changing the permissions from the vendored RPM
+  - /etc/sssd/ owner is no longer managed
+  - /etc/sssd/ perms went from 0640 to 0711
+  - /etc/init.d/sssd went from 0754 to 0755 on EL6
+
 * Wed Mar 28 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.1-0
 - sssd::provider::ad::ldap_schema should be a string, not a boolean
 - AD test cleanup

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,17 +15,10 @@ class sssd::install (
 ) {
   contain 'sssd::install::client'
 
-  if ( $facts['operatingsystem'] in ['RedHat','CentOS'] ) and ( $facts['operatingsystemmajrelease'] > '6' ) {
-    $_sssd_user = 'sssd'
-  } else {
-    $_sssd_user = 'root'
-  }
-
   file { '/etc/sssd':
     ensure  => 'directory',
-    owner   => $_sssd_user,
     group   => 'root',
-    mode    => '0640',
+    mode    => '0711',
     require => Package['sssd']
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,7 +9,7 @@ class sssd::service {
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',
-    mode    => '0754',
+    mode    => '0755',
     seltype => 'sssd_initrc_exec_t',
     source  => 'puppet:///modules/sssd/sssd.sysinit',
     notify  => Service['sssd']

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -10,26 +10,12 @@ describe 'sssd::install' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('sssd::install') }
           it { is_expected.to create_class('sssd::install::client') }
-          it {
-            if facts[:operatingsystemmajrelease] > '6'
-              is_expected.to contain_file('/etc/sssd').with({
-                :ensure  => 'directory',
-                :owner   => 'sssd',
-                :group   => 'root',
-                :mode   => '0640',
-                :require   => 'Package[sssd]',
-              })
-            else
-              is_expected.to contain_file('/etc/sssd').with({
-                :ensure  => 'directory',
-                :owner   => 'root',
-                :group   => 'root',
-                :mode   => '0640',
-                :require   => 'Package[sssd]',
-              })
-            end
-          }
-
+          it { is_expected.to contain_file('/etc/sssd').with({
+            :ensure  => 'directory',
+            :group   => 'root',
+            :mode    => '0711',
+            :require => 'Package[sssd]',
+          }) }
           it { is_expected.to contain_package('sssd').with_ensure('latest') }
           it { is_expected.to contain_package('sssd-tools').with_ensure('latest') }
           it { is_expected.to contain_package('sssd-client').with_ensure('latest') }


### PR DESCRIPTION
- Avoid changing the permissions /etc/sssd from the vendored RPM
  - owner is no longer managed
  - perms went from 0640 to 0711

SIMP-4652 #comment sssd fixed