### PR TITLE
(SIMP-4009) Add Puppet 5 and OEL Support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,6 +175,8 @@ default:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '~> 4.10'
   script:
     - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]
@@ -186,6 +188,7 @@ fips-default:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
+    PUPPET_VERSION: '~> 4.10'
     BEAKER_fips: 'yes'
   script:
     - bundle exec rake spec_clean
@@ -198,7 +201,7 @@ default-puppet5:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
-    PUPPET_VERSION: '~> 5.0'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -213,7 +216,7 @@ fips-default-puppet5:
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
     BEAKER_fips: 'yes'
-    PUPPET_VERSION: '~> 5.0'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -227,7 +230,7 @@ default-puppet5-oel:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
-    PUPPET_VERSION: '~> 5.0'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -242,7 +245,7 @@ fips-default-puppet5-oel:
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
     BEAKER_fips: 'yes'
-    PUPPET_VERSION: '~> 5.0'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -267,7 +270,7 @@ ad-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
-    PUPPET_VERSION: '~> 5.0'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -282,7 +285,7 @@ ad-puppet5-oel:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
-    PUPPET_VERSION: '~> 5.0'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,57 +61,6 @@ stages:
     variables:
       - $SIMP_FULL_MATRIX
 
-# Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
-# See: https://puppet.com/misc/puppet-enterprise-lifecycle
-# --------------------------------------
-pup4_7-validation:
-  stage: validation
-  tags:
-    - docker
-  image: ruby:2.1
-  variables:
-    PUPPET_VERSION: '~> 4.7.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *validation_checks
-
-pup4_7-unit:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.1
-  variables:
-    PUPPET_VERSION: '~> 4.7.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *spec_tests
-
-
-# Puppet 4.8 for SIMP 6.0 + 6.1 support
-# --------------------------------------
-pup4_8-validation:
-  stage: validation
-  tags:
-    - docker
-  image: ruby:2.1
-  variables:
-    PUPPET_VERSION: '~> 4.8.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *validation_checks
-
-pup4_8-unit:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.1
-  variables:
-    PUPPET_VERSION: '~> 4.8.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *spec_tests
-
-
 # Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@
 # SIMP6.0.0   4.8   2.1.9  TBD
 # PE 2017.2   4.10  2.1.9  2018-02-21
 # PE 2017.3   5.3   2.4.1  2018-07
-# PE 2018.1   ???   ?????  ????-??  (LTS)
+# PE 2018.1   5.5   2.4.4  ????-??  (LTS)
 ---
 .cache_bundler: &cache_bundler
   cache:
@@ -53,6 +53,13 @@ stages:
   - unit
   - acceptance
   - deploy
+
+# To avoid running a prohibitive number of tests every commit,
+# don't set this env var in your gitlab instance
+.only_with_SIMP_FULL_MATRIX: &only_with_SIMP_FULL_MATRIX
+  only:
+    variables:
+      - $SIMP_FULL_MATRIX
 
 # Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
@@ -155,7 +162,32 @@ pup5_3-unit:
   <<: *cache_bundler
   <<: *setup_bundler_env
   <<: *spec_tests
-  allow_failure: true
+
+
+# Puppet 5.5 for PE 2018.1 support (EOL: 2018-07)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup5_5-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup5_5-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
 
 
 # Keep an eye on the latest puppet 5
@@ -210,6 +242,63 @@ fips-default:
     - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]
 
+default-puppet5:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+  script:
+    - bundle exec rake spec_clean
+    - bundle exec rake beaker:suites[default]
+
+fips-default-puppet5:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *only_with_SIMP_FULL_MATRIX
+  variables:
+    BEAKER_fips: 'yes'
+    PUPPET_VERSION: '~> 5.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+  script:
+    - bundle exec rake spec_clean
+    - bundle exec rake beaker:suites[default]
+
+default-puppet5-oel:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *only_with_SIMP_FULL_MATRIX
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+  script:
+    - bundle exec rake spec_clean
+    - bundle exec rake beaker:suites[default,oel]
+
+fips-default-puppet5-oel:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *only_with_SIMP_FULL_MATRIX
+  variables:
+    BEAKER_fips: 'yes'
+    PUPPET_VERSION: '~> 5.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+  script:
+    - bundle exec rake spec_clean
+    - bundle exec rake beaker:suites[default,oel]
+
 ad:
   stage: acceptance
   tags:
@@ -219,4 +308,34 @@ ad:
   script:
     - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[ad]
+  retry: 1
+
+ad-puppet5:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *only_with_SIMP_FULL_MATRIX
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+  script:
+    - bundle exec rake spec_clean
+    - bundle exec rake beaker:suites[ad]
+  retry: 1
+
+ad-puppet5-oel:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *only_with_SIMP_FULL_MATRIX
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+  script:
+    - bundle exec rake spec_clean
+    - bundle exec rake beaker:suites[ad,oel]
   retry: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 # ------------------------------------------------------------------------------
 #  release    pup   ruby      eol
-# PE 2016.4   4.7   2.1.9  TBD (LTS)
-# PE 2016.5   4.8   2.1.9  2017-10-31
-# SIMP6.0.0   4.8   2.1.9  TBD
 # PE 2017.1   4.9   2.1.9  2017-10-31
 # PE 2017.2   4.10  2.1.9  TBD
 ---
@@ -54,12 +51,6 @@ jobs:
     - stage: spec
       rvm: 2.1.9
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
-      rvm: 2.1.9
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
       script:
         - bundle exec rake spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ before_install:
   - rm -f Gemfile.lock
 
 jobs:
-  allow_failures:
-    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
-
   include:
     - stage: check
       rvm: 2.4.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,10 @@
 - Fixed a bug in which the dyndns_iface setting for the AD provider was not
   set from sssd::provider::ad::dyndns_ifaces.
 
+* Thu Aug 23 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.1.3-0
+- Add support for Oracle Enterprise Linux
+- Add support for Puppet 5
+
 * Fri Jul 13 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.1.3-0
 - Added ldap_use_tokengroups, ldap_group_objectsid, ldap_user_objectsid to sssd::provider::ad
 - Updated required version of puppetlabs-stdlib to 4.19.0 since fact function is used

--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,5 @@ group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
   gem 'beaker-windows'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.10')
 end

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.10.4 < 6.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.1.4",
+  "version": "6.1.3",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",
@@ -39,12 +39,19 @@
         "6",
         "7"
       ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,3 +1,10 @@
+<%
+  if ENV['BEAKER_HYPERVISOR']
+    hypervisor = ENV['BEAKER_HYPERVISOR']
+  else
+    hypervisor = 'vagrant'
+  end
+-%>
 HOSTS:
 # For the future....
 #  centos7-svr:
@@ -22,14 +29,17 @@ HOSTS:
       - client
     platform: el-7-x86_64
     box: centos/7
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
   centos6-cli:
     roles:
       - client
     platform: el-6-x86_64
     box: centos/6
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose
   type: aio
   vagrant_memsize: 256
+<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
+  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% end -%>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -26,13 +26,13 @@ HOSTS:
       - default
       - client
     platform: el-7-x86_64
-    box: elastic/oel-7-x86_64
+    box: onyxpoint/oel-7-x86_64
     hypervisor: <%= hypervisor %>
   oel6-cli:
     roles:
       - client
     platform: el-6-x86_64
-    box: elastic/oel-6-x86_64
+    box: onyxpoint/oel-6-x86_64
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -6,30 +6,33 @@
   end
 -%>
 HOSTS:
-  ad:
-    roles:
-      - windows
-      - ad
-    platform: windows-server-amd64
-    box: opentable/win-2012r2-standard-amd64-nocm # VBOX ONLY
-    hypervisor: <%= hypervisor %>
-    vagrant_memsize: 2048
-    vagrant_cpus: 2
-    user: vagrant
-    communicator: winrm
-    is_cygwin: false
-  centos7:
+# For the future....
+#  centos7-svr:
+#    roles:
+#      - default
+#      - server
+#      - client
+#    platform: el-7-x86_64
+#    box: elastic/oel-7-x86_64
+#    hypervisor: <%= hypervisor %>
+#  centos66-svr:
+#    roles:
+#      - server
+#    platform: el-6-x86_64
+#    box: elastic/oel-6-x86_64
+#    hypervisor: <%= hypervisor %>
+  oel7-cli:
     roles:
       - default
       - client
     platform: el-7-x86_64
-    box: centos/7
-    hypervisor: vagrant
-  centos6:
+    box: elastic/oel-7-x86_64
+    hypervisor: <%= hypervisor %>
+  oel6-cli:
     roles:
       - client
     platform: el-6-x86_64
-    box: centos/6
+    box: elastic/oel-6-x86_64
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/ad/nodesets/oel.yml
+++ b/spec/acceptance/suites/ad/nodesets/oel.yml
@@ -23,13 +23,13 @@ HOSTS:
       - default
       - client
     platform: el-7-x86_64
-    box: elastic/oel-7-x86_64
+    box: onyxpoint/oel-7-x86_64
     hypervisor: vagrant
   oel6:
     roles:
       - client
     platform: el-6-x86_64
-    box: elastic/oel-6-x86_64
+    box: onyxpoint/oel-6-x86_64
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/ad/nodesets/oel.yml
+++ b/spec/acceptance/suites/ad/nodesets/oel.yml
@@ -18,18 +18,18 @@ HOSTS:
     user: vagrant
     communicator: winrm
     is_cygwin: false
-  centos7:
+  oel7:
     roles:
       - default
       - client
     platform: el-7-x86_64
-    box: centos/7
+    box: elastic/oel-7-x86_64
     hypervisor: vagrant
-  centos6:
+  oel6:
     roles:
       - client
     platform: el-6-x86_64
-    box: centos/6
+    box: elastic/oel-6-x86_64
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -11,12 +11,16 @@ include BeakerWindows::Powershell
 include BeakerWindows::Registry
 include BeakerWindows::WindowsFeature
 
-if ENV['PUPPET_VERSION']
-  # have to tell run_puppet_install_helper the version of
-  # puppet-agent that corresponds to PUPPET_VERSION
-  ENV['PUPPET_INSTALL_VERSION'] = latest_puppet_agent_version_for(ENV['PUPPET_VERSION'])
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Puppet
+    if host.is_pe?
+      install_pe
+    else
+      install_puppet
+    end
+  end
 end
-run_puppet_install_helper
 
 hosts.each do |host|
   # https://petersouter.co.uk/testing-windows-puppet-with-beaker/


### PR DESCRIPTION
Add support for Puppet 5 and OEL in metadata, Gemfile updates, and
acceptance testing.

**NOTE** The acceptance tests for OEL-AD will not pass until updates are made to pupmod-simp-ssh and the merge for pupmod-simp-simp goes through.