### PR TITLE
(SIMP-4009) OEL Support for LDAP Provider

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 18 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.1.3-0
+- Added OracleLinux to operating system check for 128 bit cipher
+  work-around
+
 * Tue Aug 28 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.3-0
 - Fixed a bug in which the ldap_account_expire_policy setting
   for the LDAP provider could not be configured to use the system

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -354,7 +354,7 @@ define sssd::provider::ldap (
     # This is here due to a bug in the LDAP client library on EL6 that will set
     # the SSF to 128 when connecting over StartTLS if there are *any* 128-bit
     # ciphers in the list.
-    if $facts['os']['name'] in ['RedHat','CentOS'] and (versioncmp($facts['os']['release']['major'],'7') < 0) {
+    if $facts['os']['name'] in ['RedHat','CentOS','OracleLinux'] and (versioncmp($facts['os']['release']['major'],'7') < 0) {
       $_ldap_tls_cipher_suite = $ldap_tls_cipher_suite + ['-AES128']
     }
     else {

--- a/spec/defines/provider/ldap_spec.rb
+++ b/spec/defines/provider/ldap_spec.rb
@@ -18,7 +18,7 @@ describe 'sssd::provider::ldap' do
         it { is_expected.to compile.with_all_deps }
 
         it do
-          if ['RedHat','CentOS'].include?(facts[:os][:name]) and facts[:os][:release][:major] < '7'
+          if ['RedHat','CentOS','OracleLinux'].include?(facts[:os][:name]) and facts[:os][:release][:major] < '7'
             ldap_tls_cipher_suite = 'ldap_tls_cipher_suite = HIGH:-SSLv2:-AES128'
           else
             ldap_tls_cipher_suite = 'ldap_tls_cipher_suite = HIGH:-SSLv2'


### PR DESCRIPTION
Adds support for 128 bit cipher workaround that was missed for OEL previously.

SIMP-4009 #comment OEL support fixed