### PR TITLE
Add a default to `domains`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Feb 20 2019 Nick Miller <nick.miller@onyxpoint.com> - 6.1.5-0
+- Set the default value for sssd::comains to ['LOCAL']
+
 * Mon Jan 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.4-0
 - Generated a REFERENCE.md
 - Set the 'min_id' settings across the board to '1' to match the sssd defaults

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Wed Feb 20 2019 Nick Miller <nick.miller@onyxpoint.com> - 6.1.5-0
-- Set the default value for sssd::comains to ['LOCAL']
+- Set the default value for sssd::domains to ['LOCAL']
 
 * Mon Jan 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.4-0
 - Generated a REFERENCE.md

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,7 @@
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd (
-  Array[String[1, 255], 1]       $domains,
+  Array[String[1, 255], 1]       $domains               = ['LOCAL'],
   Optional[Sssd::DebugLevel]     $debug_level           = undef,
   Boolean                        $debug_timestamps      = true,
   Boolean                        $debug_microseconds    = false,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is the default, minimally-destructive behavior that users probably
expect when starting a SIMP environment from scratch. It mimics the
default system state.