### PR TITLE
(SIMP-6152) Change ldap_access_order to renew

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Feb 22 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.5-0
+- Change the sssd::provider::ldap::ldap_access_order defaults to
+  ['ppolicy','pwd_expire_policy_renew'] by default to prevent accidental sysetm
+  lockouts on upgrade.
+
 * Mon Jan 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.4-0
 - Generated a REFERENCE.md
 - Set the 'min_id' settings across the board to '1' to match the sssd defaults

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * Fri Feb 22 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.5-0
 - Change the sssd::provider::ldap::ldap_access_order defaults to
-  ['ppolicy','pwd_expire_policy_renew'] by default to prevent accidental sysetm
+  ['ppolicy','pwd_expire_policy_renew'] by default to prevent accidental system
   lockouts on upgrade.
 
 * Mon Jan 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.4-0

--- a/functions/ldap_access_order_defaults.pp
+++ b/functions/ldap_access_order_defaults.pp
@@ -13,7 +13,7 @@ function sssd::ldap_access_order_defaults {
     if versioncmp($facts['sssd_version'], '1.14.0') >= 0 {
       $_result = [
         'ppolicy',
-        'pwd_expire_policy_reject'
+        'pwd_expire_policy_renew'
       ]
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/spec/defines/provider/ldap_spec.rb
+++ b/spec/defines/provider/ldap_spec.rb
@@ -85,7 +85,7 @@ describe 'sssd::provider::ldap' do
             debug_microseconds = false
             krb5_canonicalize = false
             krb5_use_kdcinfo = true
-            ldap_access_order = expire,lockout,ppolicy,pwd_expire_policy_reject
+            ldap_access_order = expire,lockout,ppolicy,pwd_expire_policy_renew
             ldap_account_expire_policy = shadow
             ldap_chpass_update_last_change = true
             ldap_default_authtok = sup3r$3cur3P@ssw0r?

--- a/spec/functions/ldap_access_order_spec.rb
+++ b/spec/functions/ldap_access_order_spec.rb
@@ -9,9 +9,9 @@ describe 'sssd::ldap_access_order_defaults' do
 
   sssd_versions = {
     '1.0.0' => defaults,
-    '1.14.0' => defaults + ['ppolicy','pwd_expire_policy_reject'],
-    '1.14.1' => defaults + ['ppolicy','pwd_expire_policy_reject'],
-    '1.15.0' => defaults + ['ppolicy','pwd_expire_policy_reject']
+    '1.14.0' => defaults + ['ppolicy','pwd_expire_policy_renew'],
+    '1.14.1' => defaults + ['ppolicy','pwd_expire_policy_renew'],
+    '1.15.0' => defaults + ['ppolicy','pwd_expire_policy_renew']
   }
 
   sssd_versions.each do |sssd_version, expected_result|


### PR DESCRIPTION
Change the sssd::provider::ldap::ldap_access_order defaults to
['ppolicy','pwd_expire_policy_renew'] by default to prevent accidental
system lockouts on upgrade.

SIMP-6152 #close