### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,11 +4,7 @@ fixtures:
     auditd: https://github.com/simp/pupmod-simp-auditd
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     pki: https://github.com/simp/pupmod-simp-pki
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.6-0
+- Expanded the upper limit of the stdlib Puppet module version
+- Updated URLs in the README.md
+
 * Fri Feb 22 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.5-0
 - Change the sssd::provider::ldap::ldap_access_order defaults to
   ['ppolicy','pwd_expire_policy_renew'] by default to prevent accidental system

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Build Status](https://travis-ci.org/simp/pupmod-simp-sssd.svg)](https://travis-ci.org/simp/pupmod-simp-sssd) [![SIMP compatibility](https://img.shields.io/badge/SIMP%20compatibility-4.2.*%2F5.1.*-orange.svg)](https://img.shields.io/badge/SIMP%20compatibility-4.2.*%2F5.1.*-orange.svg)
+[![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/73/badge)](https://bestpractices.coreinfrastructure.org/projects/73)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/simp/sssd.svg)](https://forge.puppetlabs.com/simp/sssd)
+[![Puppet Forge Downloads](https://img.shields.io/puppetforge/dt/simp/sssd.svg)](https://forge.puppetlabs.com/simp/sssd)
+[![Build Status](https://travis-ci.org/simp/pupmod-simp-sssd.svg)](https://travis-ci.org/simp/pupmod-simp-sssd)
 
 #### Table of Contents
 
@@ -15,19 +19,18 @@
 
 
 ## Overview
+
 This module installs and manages SSSD. It allows you to set config options in sssd.conf through puppet / hiera.
 
 ## This is a SIMP module
-This module is a component of the
-[System Integrity Management Platform](https://github.com/NationalSecurityAgency/SIMP),
+
+This module is a component of the [System Integrity Management Platform](https://simp-project.com),
 a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our
 [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP)
-and visit our [developer wiki](https://simp-project.atlassian.net/wiki/display/SD/SIMP+Development+Home).
-
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 This module is optimally designed for use within a larger SIMP ecosystem, but it
 can be used independently:
@@ -1430,11 +1433,4 @@ operating systems have not been tested and results cannot be guaranteed.
 
 # Development
 
-Please see the
-[SIMP Contribution Guidelines](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP).
-
-General developer documentation can be found on
-[Confluence](https://simp-project.atlassian.net/wiki/display/SD/SIMP+Development+Home).
-Visit the project homepage on [GitHub](https://simp-project.com),
-chat with us on our [HipChat](https://simp-project.hipchat.com/),
-and look at our issues on  [JIRA](https://simp-project.atlassian.net/).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.19.0 < 5.0.0"
+      "version_requirement": ">= 4.19.0 < 6.0.0"
     },
     {
       "name": "simp/auditd",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the stdlib Puppet module version
- Updated URLs in the README.md

SIMP-6213 #comment pupmod-simp-sssd