### PR TITLE
(SIMP-6922) concat pinned to wrong version in fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,10 +7,8 @@ fixtures:
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
       repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+      ref: 5.3.0
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki: https://github.com/simp/pupmod-simp-pki
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,9 +6,7 @@ fixtures:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    concat:
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 5.3.0
+    concat: https://github.com/simp/puppetlabs-concat
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki: https://github.com/simp/pupmod-simp-pki
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,6 +99,10 @@ variables:
   stage: 'validation'
   tags: ['docker']
   <<: *setup_bundler_env
+  # Temporarily we are allowing unit tests to fail in GitLab.
+  # The tests successfully run in TravisCI, but have issues with the docker
+  # containers provided by GitLab.
+  allow_failure: true
   script:
     - 'bundle exec rake spec'
 


### PR DESCRIPTION
- Tested with concat 5.3.0 to ensure compatibility with SIMP 6.4.0
- Updated fixtures to latest and greatest (6.x currently)
- Allow spec tests to fail in GitLab.  They pass in TravisCI.  There is a separate ticket for that problem: SIMP 6932