### PR TITLE
[SIMP-7240] Deprecate the 'local' provider on EL7+

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Thu Apr 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0-0
+* Thu Apr 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.1-0
 - Ensure that EL6/7+ use the 'files' or 'local' provider as is appropriate for
   their platform
 - Migrate the documentation to focus on the 'files' provider since 'local' is

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Thu Apr 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0-0
+- Ensure that EL6/7+ use the 'files' or 'local' provider as is appropriate for
+  their platform
+- Migrate the documentation to focus on the 'files' provider since 'local' is
+  not recommended to be used any longer
+- Fixed the core acceptance tests
+
 * Tue Jan 21 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.3.0-0
 - Added EL8 support
 - Removed requirement for sssd domain entry for el8 and SSSD V2 since

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,8 +15,7 @@ class sssd::config {
     group          => 'root',
     mode           => '0600',
     ensure_newline => true,
-    warn           => true,
-    notify         => Class['sssd::service']
+    warn           => true
   }
 
   if ($sssd::auto_add_ipa_domain and $facts['ipa']) {
@@ -46,7 +45,7 @@ class sssd::config {
 
   # You must have a domain in el6 or el7 unless you updated to sssd V2 or sssd will
   # not start. Check here instead of init because IPA domain might have been added.
-  if $facts['os']['release']['major'] <= '7' and size($_domains) == 0 {
+  if ($facts['os']['release']['major'] <= '7') and empty($_domains) and !$_enable_files_domain {
     unless  $facts['sssd_version'] and versioncmp($facts['sssd_version'],'2.0') >= 0  {
       fail("${module_name}: SSSD requires a domain be defined. \$sssd::domains is empty.")
     }
@@ -63,5 +62,4 @@ class sssd::config {
     content => template("${module_name}/sssd.conf.erb"),
     order   => '10'
   }
-
 }

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -112,11 +112,16 @@ define sssd::domain (
   Optional[String]                           $proxy_pam_target             = undef,
   Optional[String]                           $proxy_lib_name               = undef
 ) {
-  include '::sssd'
+  include 'sssd'
 
-  if $facts['os']['release']['major']  < '7' {
+  if $facts['os']['release']['major']  > '6' {
+    if $id_provider == 'local' {
+      warning( "Invalid SSSD configuration. 'local' is not a valid provider for os version ${facts['os']['release']['major']}'")
+    }
+  }
+  else {
     if $id_provider == 'files' {
-      warn( "Invalid SSSD configuration.  'files' is not a valid provider for os version ${facts['os']['release']['major']}'")
+      warning( "Invalid SSSD configuration. 'files' is not a valid provider for os version ${facts['os']['release']['major']}'")
     }
   }
 

--- a/manifests/provider/ad.pp
+++ b/manifests/provider/ad.pp
@@ -1,5 +1,6 @@
-# Set up the 'ad' (Active Directory) id_provider section of a particular
-# domain.
+# @summary Set up the 'ad' (Active Directory) id_provider section of a particular domain.
+#
+# NOTE: You MUST connect the system to the domain prior to using this defined type.
 #
 # Any parameter not explicitly documented directly follows the documentation
 # from sssd-ad(5).
@@ -139,9 +140,9 @@ define sssd::provider::ad (
   Optional[String[1]]                                        $ldap_group_objectsid                     = undef,
   Optional[String[1]]                                        $ldap_user_objectsid                      = undef,
 ) {
-  include '::sssd'
+  include $module_name
 
-  concat::fragment { "sssd_${name}_ad_provider.domain":
+  concat::fragment { "${module_name}_${name}_ad_provider.domain":
     target  => '/etc/sssd/sssd.conf',
     content => template("${module_name}/provider/ad.erb"),
     order   => $name

--- a/manifests/provider/files.pp
+++ b/manifests/provider/files.pp
@@ -1,6 +1,7 @@
-# Define: sssd::provider::files
+# @summary Configures the 'files' id_provider section of a particular domain.
 #
-# This define sets up the 'files' id_provider section of a particular domain.
+# NOTE: This defined type has no effect on SSSD < 1.16.0
+#
 # $name should be the name of the associated domain in sssd.conf.
 #
 # This is not necessary for the file provider unless you want to use
@@ -17,14 +18,16 @@
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 define sssd::provider::files (
-  Optional[Array[Stdlib::Absolutepath]]        $passwd_files    = undef,
-  Optional[Array[Stdlib::Absolutepath]]        $group_files     = undef
+  Optional[Array[Stdlib::Absolutepath]] $passwd_files = undef,
+  Optional[Array[Stdlib::Absolutepath]] $group_files  = undef
 ) {
-  include '::sssd'
+  if $facts['os']['release']['major']  > '6' {
+    include $module_name
 
-  concat::fragment { "sssd_${name}_files.domain":
-    target  => '/etc/sssd/sssd.conf',
-    content => template('sssd/provider/files.erb'),
-    order   => $name
+    concat::fragment { "${module_name}_${name}_files.domain":
+      target  => '/etc/sssd/sssd.conf',
+      content => template("${module_name}/provider/files.erb"),
+      order   => $name
+    }
   }
 }

--- a/manifests/provider/ipa.pp
+++ b/manifests/provider/ipa.pp
@@ -76,7 +76,7 @@ define sssd::provider::ipa (
   Boolean                        $use_service_discovery          = true
 
 ) {
-  include '::sssd'
+  include $module_name
 
   if $use_service_discovery {
     $_ipa_server = ['_srv_'] + $ipa_server
@@ -85,9 +85,9 @@ define sssd::provider::ipa (
     $_ipa_server = $ipa_server
   }
 
-  concat::fragment { "sssd_${name}_ipa_provider.domain":
+  concat::fragment { "${module_name}_${name}_ipa_provider.domain":
     target  => '/etc/sssd/sssd.conf',
-    content => template('sssd/provider/ipa.erb'),
+    content => template("${module_name}/provider/ipa.erb"),
     order   => $name
   }
 }

--- a/manifests/provider/krb5.pp
+++ b/manifests/provider/krb5.pp
@@ -45,9 +45,9 @@ define sssd::provider::krb5 (
   Integer                                $krb5_renew_interval            = 0,
   Optional[Enum['never','try','demand']] $krb5_use_fast                  = undef
 ) {
-  include '::sssd'
+  include $module_name
 
-  concat::fragment { "sssd_${name}_krb5_provider.domain":
+  concat::fragment { "${module_name}_${name}_krb5_provider.domain":
     target  => '/etc/sssd/sssd.conf',
     content => template("${module_name}/provider/krb5.erb"),
     order   => $name

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -348,7 +348,7 @@ define sssd::provider::ldap (
   Optional[String[1]]                   $ldap_idmap_default_domain         = undef,
   Boolean                               $ldap_idmap_autorid_compat         = false
 ) {
-  include '::sssd'
+  include $module_name
 
   if $strip_128_bit_ciphers {
     # This is here due to a bug in the LDAP client library on EL6 that will set
@@ -381,18 +381,18 @@ define sssd::provider::ldap (
   if $app_pki_key {
     $ldap_tls_key = $app_pki_key
   } else {
-    $ldap_tls_key = "${sssd::app_pki_dir}/private/${::fqdn}.pem"
+    $ldap_tls_key = "${sssd::app_pki_dir}/private/${$facts['fqdn']}.pem"
   }
 
   if $app_pki_cert {
     $ldap_tls_cert = $app_pki_cert
   } else {
-    $ldap_tls_cert = "${sssd::app_pki_dir}/public/${::fqdn}.pub"
+    $ldap_tls_cert = "${sssd::app_pki_dir}/public/${$facts['fqdn']}.pub"
   }
 
-  concat::fragment { "sssd_${name}_ldap_provider.domain":
+  concat::fragment { "${module_name}_${name}_ldap_provider.domain":
     target  => '/etc/sssd/sssd.conf',
-    content => template('sssd/provider/ldap.erb'),
+    content => template("${module_name}/provider/ldap.erb"),
     order   => $name
   }
 }

--- a/manifests/provider/local.pp
+++ b/manifests/provider/local.pp
@@ -1,11 +1,8 @@
-# Define: sssd::provider::local
+# @summary Configures the 'LOCAL' id_provider section of a particular domain.
 #
-# This define sets up the 'local' id_provider section of a particular domain.
+# NOTE: This provider has NO EFFECT on SSSD 1.16.0+
+#
 # $name should be the name of the associated domain in sssd.conf.
-#
-# In EL8, which uses SSSD V2, the local provider is not available by default.
-# It will prevent sssd from running but it will not work unless you have a specially
-# copiled version of sssd v2.
 #
 # See 'The local domain section' in sssd.conf(5) for additional information.
 #
@@ -27,23 +24,25 @@
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 define sssd::provider::local (
-  Optional[Sssd::DebugLevel]      $debug_level        = undef,
-  Boolean                         $debug_timestamps   = true,
-  Boolean                         $debug_microseconds = false,
-  Optional[String]                $default_shell      = undef,
-  Optional[Stdlib::Absolutepath]  $base_directory     = undef,
-  Boolean                         $create_homedir     = true,
-  Boolean                         $remove_homedir     = true,
-  Optional[Simplib::Umask]        $homedir_umask      = undef,
-  Optional[Stdlib::Absolutepath]  $skel_dir           = undef,
-  Optional[Stdlib::Absolutepath]  $mail_dir           = undef,
-  Optional[String]                $userdel_cmd        = undef
+  Optional[Sssd::DebugLevel]     $debug_level        = undef,
+  Boolean                        $debug_timestamps   = true,
+  Boolean                        $debug_microseconds = false,
+  Optional[String]               $default_shell      = undef,
+  Optional[Stdlib::Absolutepath] $base_directory     = undef,
+  Boolean                        $create_homedir     = true,
+  Boolean                        $remove_homedir     = true,
+  Optional[Simplib::Umask]       $homedir_umask      = undef,
+  Optional[Stdlib::Absolutepath] $skel_dir           = undef,
+  Optional[Stdlib::Absolutepath] $mail_dir           = undef,
+  Optional[String]               $userdel_cmd        = undef
 ) {
-  include '::sssd'
+  if $facts['os']['release']['major']  < '7' {
+    include $module_name
 
-  concat::fragment { "sssd_${name}_local_provider.domain":
-    target  => '/etc/sssd/sssd.conf',
-    content => template('sssd/provider/local.erb'),
-    order   => $name
+    concat::fragment { "${module_name}_${name}_local_provider.domain":
+      target  => '/etc/sssd/sssd.conf',
+      content => template("${module_name}/provider/local.erb"),
+      order   => $name
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/10_sssd_conf_spec.rb
+++ b/spec/acceptance/suites/default/10_sssd_conf_spec.rb
@@ -19,55 +19,77 @@ describe 'sssd' do
     'simp_options::ldap::bind_pw' => '<PASSWORD>',
     # This causes a lot of noise and reboots
     'sssd::auditd'                => false,
-    'sssd::domains'               => [ 'LOCAL','test.case' ],
+    'sssd::domains'               => [ 'local','test.case' ],
     'sssd::services'              => ['nss','pam'],
   }
-  manifest = <<-EOF
-      include '::sssd'
-      include '::sssd::service::nss'
-      include '::sssd::service::pam'
-      include '::sssd::service::autofs'
-      include '::sssd::service::sudo'
-      include '::sssd::service::ssh'
 
-      # LOCAL CONFIG
-      sssd::domain { 'LOCAL':
-        description       => 'LOCAL Users Domain',
-        id_provider       => 'local',
-        auth_provider     => 'local',
-        access_provider   => 'permit',
-        min_id            => 1000,
-        enumerate         => false,
-        cache_credentials => false
-      }
-      sssd::provider::local { 'LOCAL': }
+  let(:manifest) { <<-EOF
+      include 'sssd'
+      include 'sssd::service::nss'
+      include 'sssd::service::pam'
+      include 'sssd::service::autofs'
+      include 'sssd::service::sudo'
+      include 'sssd::service::ssh'
+
+      #{local_config}
 
       # LDAP CONFIG
       sssd::domain { 'LDAP':
-        description       => 'LDAP Users Domain',
-        id_provider       => 'ldap',
-        auth_provider     => 'ldap',
-        chpass_provider   => 'ldap',
-        access_provider   => 'ldap',
-        sudo_provider     => 'ldap',
-        autofs_provider   => 'ldap',
-        min_id            => 1000,
-        enumerate         => false,
-        cache_credentials => true,
+        description               => 'LDAP Users Domain',
+        id_provider               => 'ldap',
+        auth_provider             => 'ldap',
+        chpass_provider           => 'ldap',
+        access_provider           => 'ldap',
+        sudo_provider             => 'ldap',
+        autofs_provider           => 'ldap',
+        min_id                    => 1000,
+        enumerate                 => false,
+        cache_credentials         => true,
         use_fully_qualified_names => false,
       }
       sssd::provider::ldap { 'LDAP':
-        ldap_user_gecos => 'dn',
-        ldap_id_mapping => false,
-        app_pki_key     => '/etc/pki/simp_apps/sssd/x509/private/host.test.case.pem',
-        app_pki_cert    => '/etc/pki/simp_apps/sssd/x509/public/host.test.case.pub',
+        ldap_user_gecos           => 'dn',
+        ldap_id_mapping           => false,
+        app_pki_key               => '/etc/pki/simp_apps/sssd/x509/private/host.test.case.pem',
+        app_pki_cert              => '/etc/pki/simp_apps/sssd/x509/public/host.test.case.pub',
         ldap_default_authtok_type => 'password',
       }
     EOF
+  }
+
   context 'generate a good sssd.conf' do
     hosts.each do |host|
+
+      if fact_on(host, 'operatingsystemmajrelease') < '7'
+        let(:local_config) { <<~EOM
+            # LOCAL CONFIG
+            sssd::domain { 'local':
+              description       => 'LOCAL Users Domain',
+              id_provider       => 'local',
+              auth_provider     => 'local',
+              access_provider   => 'permit',
+              min_id            => 1000,
+              enumerate         => false,
+              cache_credentials => false
+            }
+            sssd::provider::local { 'local': }
+          EOM
+        }
+
+        local_hiera = hiera
+      else
+        let(:local_config) { '' }
+
+        local_hiera = hiera.merge(
+          {
+            'sssd::enable_files_domain' => true,
+            'sssd::domains'             => [ 'test.case' ]
+          }
+        )
+      end
+
       it 'should apply enough to generate sssd.conf' do
-        set_hieradata_on(host, hiera)
+        set_hieradata_on(host, local_hiera)
         apply_manifest_on(host, manifest)
       end
 

--- a/spec/acceptance/suites/ldap/templates/server_hieradata_tls.yaml.erb
+++ b/spec/acceptance/suites/ldap/templates/server_hieradata_tls.yaml.erb
@@ -28,4 +28,3 @@ simp_options::ldap::root_dn: 'cn=LDAPAdmin,ou=People,<%= base_dn %>'
 simp_options::ldap::master: 'ldap://<%= server_fqdn %>'
 # suP3rP@ssw0r!
 simp_openldap::server::conf::rootpw: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"
-#sssd::domains: ['LOCAL', 'LDAP']

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -44,8 +44,7 @@ shared_examples_for 'a sssd::config' do |content|
       :group          => 'root',
       :mode           => '0600',
       :ensure_newline => true,
-      :warn           => true,
-      :notify         => 'Class[Sssd::Service]'
+      :warn           => true
     })
   }
 

--- a/spec/defines/provider/files_spec.rb
+++ b/spec/defines/provider/files_spec.rb
@@ -6,35 +6,44 @@ describe 'sssd::provider::files' do
       context "on #{os}" do
         let(:facts){ os_facts }
         let(:title) {'test_files_provider'}
-        let(:precondition){
-          'include ::sssd'
-        }
 
-        context('with default parameters') do
-          it { is_expected.to compile.with_all_deps }
-          it {
-            expected_content = <<EOM
-# sssd::provider::files
-EOM
-            is_expected.to create_concat__fragment("sssd_#{title}_files.domain").with_content(expected_content)
-           }
-        end
+        if os_facts[:operatingsystemmajrelease] > '6'
+          context('with default parameters') do
+            it { is_expected.to compile.with_all_deps }
 
-        context('with explicit parameters') do
-          let(:params) {{
-            :passwd_files   => [ '/etc/passwd1', '/etc/passwd2'],
-            :group_files   => [ '/etc/group1', '/etc/group2'],
-          }}
+            it {
+              expected_content = <<~EOM
+                # sssd::provider::files
+              EOM
 
-          it { is_expected.to compile.with_all_deps }
-          it {
-            expected_content = <<EOM
-# sssd::provider::files
-passwd_files = /etc/passwd1, /etc/passwd2
-group_files = /etc/group1, /etc/group2
-EOM
-            is_expected.to create_concat__fragment("sssd_#{title}_files.domain").with_content(expected_content)
-           }
+              is_expected.to create_concat__fragment("sssd_#{title}_files.domain").with_content(expected_content)
+             }
+          end
+
+          context('with explicit parameters') do
+            let(:params) {{
+              :passwd_files   => [ '/etc/passwd1', '/etc/passwd2'],
+              :group_files   => [ '/etc/group1', '/etc/group2'],
+            }}
+
+            it { is_expected.to compile.with_all_deps }
+
+            it {
+              expected_content = <<~EOM
+                # sssd::provider::files
+                passwd_files = /etc/passwd1, /etc/passwd2
+                group_files = /etc/group1, /etc/group2
+              EOM
+
+              is_expected.to create_concat__fragment("sssd_#{title}_files.domain").with_content(expected_content)
+             }
+          end
+        else
+          context('with default parameters') do
+            it { is_expected.to compile.with_all_deps }
+
+            it { is_expected.not_to create_concat__fragment("sssd_#{title}_files.domain") }
+          end
         end
       end
     end

--- a/spec/defines/provider/local_spec.rb
+++ b/spec/defines/provider/local_spec.rb
@@ -2,14 +2,19 @@ require 'spec_helper'
 
 describe 'sssd::provider::local' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts){ facts }
+        let(:facts){ os_facts }
 
         let(:title) {'test_local_domain'}
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat__fragment("sssd_#{title}_local_provider.domain").without_content(%r(=\s*$)) }
+
+        if os_facts[:operatingsystemmajrelease] < '7'
+          it { is_expected.to create_concat__fragment("sssd_#{title}_local_provider.domain").without_content(%r(=\s*$)) }
+        else
+          it { is_expected.not_to create_concat__fragment("sssd_#{title}_local_provider.domain") }
+        end
       end
     end
   end

--- a/templates/provider/local.erb
+++ b/templates/provider/local.erb
@@ -1,12 +1,6 @@
 
 # sssd::provider::local
 #
-<%   if ['RedHat','CentOS','OracleLinux'].include?(@facts['operatingsystem']) && (@facts['operatingsystemmajrelease'].to_s <= "7") -%>
-# 'local' provider was removed from sssd v2 but can be used if special
-# options are used to compile it.  If the local provider is not working
-# and you are using sssd v2 or later please refer to the release notes
-# for sssd v2.0.
-<% end -%>
 <% if @debug_level -%>
 debug_level = <%= @debug_level %>
 <% end -%>


### PR DESCRIPTION
- Ensure that EL6/7+ use the 'files' or 'local' provider as is appropriate for
  their platform
- Migrate the documentation to focus on the 'files' provider since 'local' is
  not recommended to be used any longer
- Fixed the core acceptance tests

SIMP-7240 #close