### PR TITLE
(SIMP-MAINT) IPA edge case fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Feb 18 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.4.0-0
+- Ensure that systems bound to FreeIPA, but not connected do not cause
+  compilation issues.
+
 * Wed Jan 13 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.4.0-0
 - Removed EL6 from supported OSes
 - Added puppet 7 support

--- a/manifests/config/ipa_domain.pp
+++ b/manifests/config/ipa_domain.pp
@@ -2,7 +2,8 @@
 #
 class sssd::config::ipa_domain {
   assert_private()
-  if $facts['ipa'] {
+
+  if $facts.dig('ipa', 'connected') {
     # this host has joined an IPA domain
     $_ipa_domain = $facts['ipa']['domain']
     $_ipa_server = $facts['ipa']['server']
@@ -15,9 +16,9 @@ class sssd::config::ipa_domain {
       access_provider   => 'ipa',
       sudo_provider     => 'ipa',
       autofs_provider   => 'ipa',
-      min_id            => $::sssd::min_id,
-      enumerate         => $::sssd::enumerate_users,
-      cache_credentials => $::sssd::cache_credentials
+      min_id            => $sssd::min_id,
+      enumerate         => $sssd::enumerate_users,
+      cache_credentials => $sssd::cache_credentials
     }
 
     sssd::provider::ipa { $_ipa_domain:

--- a/spec/classes/config/ipa_domain_spec.rb
+++ b/spec/classes/config/ipa_domain_spec.rb
@@ -1,51 +1,68 @@
 require 'spec_helper'
 
-shared_examples_for 'a sssd::config::ipa_domain' do
-  it { is_expected.to compile.with_all_deps }
-  it { is_expected.to contain_class('sssd::config::ipa_domain') }
-  it { is_expected.to contain_sssd__domain('ipa.example.com').with({
-      :description       => 'IPA Domain ipa.example.com',
-      :id_provider       => 'ipa',
-      :auth_provider     => 'ipa',
-      :chpass_provider   => 'ipa',
-      :access_provider   => 'ipa',
-      :sudo_provider     => 'ipa',
-      :autofs_provider   => 'ipa',
-      :min_id            => 1,
-      :enumerate         => false,
-      :cache_credentials => true
-    })
-  }
-
-  it { is_expected.to contain_sssd__provider__ipa('ipa.example.com').with({
-      :ipa_domain => 'ipa.example.com',
-      :ipa_server => [ 'ipaserver.example.com' ]
-    })
-  }
-end
-
-# We have to test sssd::config::ipa_config via sssd, because
-# sssd::config:ipa_config is private.  To take advantage of hooks built
-# into puppet-rspec, the class described needs to be the class
-# instantiated, i.e., sssd.
-describe 'sssd' do
-  let(:ipa_fact_joined) {
-    {
-      :ipa => {
-        :domain => 'ipa.example.com',
-        :server => 'ipaserver.example.com',
-      }
-    }
-  }
+describe 'sssd::config::ipa_domain' do
+  let(:pre_condition) do
+    <<~PRECOND
+      function assert_private {}
+      include sssd
+    PRECOND
+  end
 
   context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         context 'when joined to an IPA domain' do
-          let(:facts) { os_facts.merge(ipa_fact_joined) }
-          let(:params) {{ :domains => ['ipa.example.com'] }}
+          let(:facts) do
+            os_facts.merge(
+              :ipa => {
+                :basedn => "dc=example,dc=com",
+                :domain => 'ipa.example.com',
+                :realm => 'EXAMPLE.COM',
+                :server => 'ipaserver.example.com',
+                :connected => true
+              }
+            )
+          end
 
-          it_should_behave_like 'a sssd::config::ipa_domain'
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('sssd::config::ipa_domain') }
+          it do
+            is_expected.to contain_sssd__domain('ipa.example.com')
+              .with_description('IPA Domain ipa.example.com')
+              .with_id_provider('ipa')
+              .with_auth_provider('ipa')
+              .with_chpass_provider('ipa')
+              .with_access_provider('ipa')
+              .with_sudo_provider('ipa')
+              .with_autofs_provider('ipa')
+              .with_min_id(1)
+              .with_enumerate(false)
+              .with_cache_credentials(true)
+          end
+
+          it do
+            is_expected.to contain_sssd__provider__ipa('ipa.example.com')
+              .with_ipa_domain('ipa.example.com')
+              .with_ipa_server(['ipaserver.example.com'])
+          end
+        end
+
+        context 'when not joined to an IPA domain' do
+          let(:facts) do
+            os_facts.merge(
+              :ipa => {
+                :basedn => "dc=example,dc=com",
+                :domain => 'ipa.example.com',
+                :realm => 'EXAMPLE.COM',
+                :connected => false
+              }
+            )
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('sssd::config::ipa_domain') }
+          it { is_expected.not_to contain_sssd__domain('ipa.example.com') }
+          it { is_expected.not_to contain_sssd__provider__ipa('ipa.example.com') }
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,6 @@ RSpec.configure do |c|
   }
 
   c.mock_framework = :rspec
-  c.mock_with :mocha
 
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')


### PR DESCRIPTION
- Ensure that systems bound to FreeIPA, but not connected do not cause
  compilation issues.