### PR TITLE
(SIMP-9603) Switch Windows SUT to devopsgroup-io/

### DIFF
--- a/spec/acceptance/suites/ad/nodesets/default.yml
+++ b/spec/acceptance/suites/ad/nodesets/default.yml
@@ -11,7 +11,7 @@ HOSTS:
       - windows
       - ad
     platform: windows-server-amd64
-    box: opentable/win-2012r2-standard-amd64-nocm # VBOX ONLY
+    box: devopsgroup-io/windows_server-2012r2-standard-amd64-nocm # VBOX ONLY
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 2048
     vagrant_cpus: 2

--- a/spec/acceptance/suites/ad/nodesets/oel.yml
+++ b/spec/acceptance/suites/ad/nodesets/oel.yml
@@ -11,7 +11,7 @@ HOSTS:
       - windows
       - ad
     platform: windows-server-amd64
-    box: opentable/win-2012r2-standard-amd64-nocm # VBOX ONLY
+    box: devopsgroup-io/windows_server-2012r2-standard-amd64-nocm # VBOX ONLY
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 2048
     vagrant_cpus: 2


### PR DESCRIPTION
This patch updates the Beaker nodesets' Windows boxes, replacing the
(currently 403) opentable/ boxes with boxes from devopsgroup-io/.

[SIMP-9605] #close
[SIMP-9603] #comment upgraded simp/sssd to devopsgroup-io box

[SIMP-9605]: https://simp-project.atlassian.net/browse/SIMP-9605
[SIMP-9603]: https://simp-project.atlassian.net/browse/SIMP-9603