### PR TITLE
(SIMP-9720) Fix sssd-sudo.socket service

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Jun 02 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.1
+- Fixed:
+  - sssd-sudo.socket service
+
 * Wed May 19 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0
 - Fixed:
   - `sssd::provider::ldap::ldap_pwd_policy` is based on the value in

--- a/manifests/service/sudo.pp
+++ b/manifests/service/sudo.pp
@@ -46,11 +46,8 @@ class sssd::service::sudo (
   }
 
   service { 'sssd-sudo.socket':
-    ensure  => 'running',
     enable  => true,
-    require => [
-      Sssd::Config::Entry['puppet_service_sudo'],
-      Class["${module_name}::service"]
-    ]
+    require => Sssd::Config::Entry['puppet_service_sudo'],
+    notify  => Class["${module_name}::service"]
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",


### PR DESCRIPTION
The sssd-sudo.socket service needed to be enabled, but not actively managed
since the sssd service itself would do that.

[SIMP-9720] #comment fix sssd issue

[SIMP-9720]: https://simp-project.atlassian.net/browse/SIMP-9720