### PR TITLE
(SIMP-9778) No domains cause failure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 * Thu Jun 03 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.0.2
 - Added tests for ds389 ldap server
+- SSSD will not start and the module fail if no domains are
+  defined.  The enable_files_domain setting is set to true to ensure
+  that sssd will start.
 
 * Wed Jun 02 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.1
 - Fixed:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,7 @@ class sssd (
   Optional[String[1]]           $user                  = undef,
   Optional[String[1]]           $default_domain_suffix = undef,
   Optional[String[1]]           $override_space        = undef,
-  Optional[Boolean]             $enable_files_domain   = undef,
+  Boolean                       $enable_files_domain   = true,
   Boolean                       $enumerate_users       = false,
   Boolean                       $cache_credentials     = true,
   Boolean                       $include_svc_config    = true,


### PR DESCRIPTION
- sssd fails to start if it has no sssd domains configured.
  This fix enables the implicit_files_domain by default.

SIMP-9778 #close