### PR TITLE
(SIMP-10414) Fix sssd-sudo service permissions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Aug 05 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.1
+- Add an override for sssd-sudo.service to start it as root:root. This aligns
+  with how sssd itself would start the service and the daemon cannot access
+  /var/lib/sss/db/config.ldb otherwise.
+
 * Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.1.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -145,11 +145,11 @@ Default value: ``undef``
 
 ##### <a name="enable_files_domain"></a>`enable_files_domain`
 
-Data type: `Optional[Boolean]`
+Data type: `Boolean`
 
 
 
-Default value: ``undef``
+Default value: ``true``
 
 ##### <a name="config_file_version"></a>`config_file_version`
 

--- a/manifests/service/sudo.pp
+++ b/manifests/service/sudo.pp
@@ -49,8 +49,10 @@ class sssd::service::sudo (
     # This is required due to the permissions on /var/lib/sss/db/config.ldb
     # This may be a regression in sssd
     [Service]
-    User = root
-    Group = root
+    ExecStartPre=-/bin/touch /var/log/sssd/sssd_sudo.log
+    ExecStartPre=-/bin/chown sssd:sssd /var/log/sssd/sssd_sudo.log
+    User=root
+    Group=root
     | END
 
   systemd::dropin_file { '00_sssd_sudo_user_group.conf':

--- a/manifests/service/sudo.pp
+++ b/manifests/service/sudo.pp
@@ -54,9 +54,10 @@ class sssd::service::sudo (
     | END
 
   systemd::dropin_file { '00_sssd_sudo_user_group.conf':
-    unit          => 'sssd-sudo.service',
-    content       => $_override_content,
-    daemon_reload => 'eager'
+    unit                    => 'sssd-sudo.service',
+    content                 => $_override_content,
+    daemon_reload           => 'eager',
+    selinux_ignore_defaults => true
   }
 
   service { 'sssd-sudo.socket':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",
@@ -12,6 +12,10 @@
     "sssd"
   ],
   "dependencies": [
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 2.2.0 < 3.0.0"
+    },
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 6.6.0 < 8.0.0"

--- a/spec/acceptance/suites/ds389/10_setup_clients_spec.rb
+++ b/spec/acceptance/suites/ds389/10_setup_clients_spec.rb
@@ -91,6 +91,11 @@ describe '389ds' do
           response = YAML.safe_load(on(client, %(puppet resource service sssd-sudo --to_yaml)).stdout)
           expect(response['service']['sssd-sudo']['ensure']).to eq('running')
         end
+
+        it 'should have a sssd_sudo.log file after querying for sudo rules' do
+          response = YAML.safe_load(on(client, %(puppet resource file /var/log/sssd_sudo.log --to_yaml)).stdout)
+          expect(response['file']['/var/log/sssd_sudo.log']['ensure']).to eq('file')
+        end
       end
     end
   end

--- a/spec/acceptance/suites/ds389/10_setup_clients_spec.rb
+++ b/spec/acceptance/suites/ds389/10_setup_clients_spec.rb
@@ -43,9 +43,10 @@ describe '389ds' do
     }
 
     class { 'nsswitch':
-      passwd => ['sss', 'files'],
-      group  => ['sss', 'files'],
-      shadow => ['sss', 'files'],
+      passwd  => ['sss', 'files'],
+      group   => ['sss', 'files'],
+      shadow  => ['sss', 'files'],
+      sudoers => ['files', 'sss']
     }
     EOS
   }
@@ -84,8 +85,13 @@ describe '389ds' do
             expect(id.stdout).to match(/#{user}/)
           end
         end
-      end
 
+        it 'should run sssd-sudo after querying for sudo rules' do
+          on(client, 'sudo -l')
+          response = YAML.safe_load(on(client, %(puppet resource service sssd-sudo --to_yaml)).stdout)
+          expect(response['service']['sssd-sudo']['ensure']).to eq('running')
+        end
+      end
     end
   end
 end

--- a/spec/acceptance/suites/ds389/10_setup_clients_spec.rb
+++ b/spec/acceptance/suites/ds389/10_setup_clients_spec.rb
@@ -93,8 +93,8 @@ describe '389ds' do
         end
 
         it 'should have a sssd_sudo.log file after querying for sudo rules' do
-          response = YAML.safe_load(on(client, %(puppet resource file /var/log/sssd_sudo.log --to_yaml)).stdout)
-          expect(response['file']['/var/log/sssd_sudo.log']['ensure']).to eq('file')
+          response = YAML.safe_load(on(client, %(puppet resource file /var/log/sssd/sssd_sudo.log --to_yaml)).stdout)
+          expect(response['file']['/var/log/sssd/sssd_sudo.log']['ensure']).to eq('file')
         end
       end
     end

--- a/spec/acceptance/suites/ds389/nodesets/default.yml
+++ b/spec/acceptance/suites/ds389/nodesets/default.yml
@@ -6,21 +6,23 @@
   end
 -%>
 HOSTS:
-  ldapserver:
+  ldapserver.beaker:
     roles:
       - ldap
       - default
     platform: el-8-x86_64
     box: generic/centos8
     hypervisor: <%= hypervisor %>
-  centos8:
+
+  centos8.beaker:
     roles:
       - client
       - sssdv2
     platform: el-8-x86_64
     box: generic/centos8
     hypervisor: <%= hypervisor %>
-  centos7:
+
+  centos7.beaker:
     roles:
       - client
       - sssdv1

--- a/spec/acceptance/suites/ds389/nodesets/oel.yml
+++ b/spec/acceptance/suites/ds389/nodesets/oel.yml
@@ -6,20 +6,22 @@
   end
 -%>
 HOSTS:
-  ldapserver:
+  ldapserver.beaker:
     roles:
       - ldap
     platform: el-8-x86_64
     box:  generic/oracle8
     hypervisor: <%= hypervisor %>
-  oel8:
+
+  oel8.beaker:
     roles:
       - default
       - client
     platform: el-8-x86_64
     box: generic/oracle8
     hypervisor: <%= hypervisor %>
-  oel7:
+
+  oel7.beaker:
     roles:
       - client
     platform: el-7-x86_64

--- a/spec/classes/service/sudo_spec.rb
+++ b/spec/classes/service/sudo_spec.rb
@@ -14,6 +14,7 @@ describe 'sssd::service::sudo' do
             .with_content(/User = root/)
             .with_content(/Group = root/)
             .with_daemon_reload('eager')
+            .with_selinux_ignore_defaults(true)
         }
         it {
           is_expected.to create_service('sssd-sudo.socket')

--- a/spec/classes/service/sudo_spec.rb
+++ b/spec/classes/service/sudo_spec.rb
@@ -8,6 +8,20 @@ describe 'sssd::service::sudo' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_sssd__config__entry('puppet_service_sudo').without_content(%r(=\s*$)) }
+        it {
+          is_expected.to create_systemd__dropin_file('00_sssd_sudo_user_group.conf')
+            .with_unit('sssd-sudo.service')
+            .with_content(/User = root/)
+            .with_content(/Group = root/)
+            .with_daemon_reload('eager')
+        }
+        it {
+          is_expected.to create_service('sssd-sudo.socket')
+            .with_enable(true)
+            .that_requires('Sssd::Config::Entry[puppet_service_sudo]')
+            .that_requires('Systemd::Dropin_file[00_sssd_sudo_user_group.conf]')
+            .that_notifies('Class[sssd::service]')
+        }
       end
     end
   end

--- a/spec/classes/service/sudo_spec.rb
+++ b/spec/classes/service/sudo_spec.rb
@@ -11,8 +11,10 @@ describe 'sssd::service::sudo' do
         it {
           is_expected.to create_systemd__dropin_file('00_sssd_sudo_user_group.conf')
             .with_unit('sssd-sudo.service')
-            .with_content(/User = root/)
-            .with_content(/Group = root/)
+            .with_content(%r(ExecStartPre=-/bin/touch /var/log/sssd/sssd_sudo.log))
+            .with_content(%r(ExecStartPre=-/bin/chown sssd:sssd /var/log/sssd/sssd_sudo.log))
+            .with_content(/User=root/)
+            .with_content(/Group=root/)
             .with_daemon_reload('eager')
             .with_selinux_ignore_defaults(true)
         }


### PR DESCRIPTION
- Add an override for sssd-sudo.service to start it as root:root. This aligns
  with how sssd itself would start the service and the daemon cannot access
  /var/lib/sss/db/config.ldb otherwise.

SIMP-10414 #close