### PR TITLE
New voxpupuli maintained systemd module has no support for daemon_reload

### DIFF
--- a/manifests/service/sudo.pp
+++ b/manifests/service/sudo.pp
@@ -58,8 +58,14 @@ class sssd::service::sudo (
   systemd::dropin_file { '00_sssd_sudo_user_group.conf':
     unit                    => 'sssd-sudo.service',
     content                 => $_override_content,
-    daemon_reload           => 'eager',
-    selinux_ignore_defaults => true
+    selinux_ignore_defaults => true,
+    notify                  => Exec['00_sssd_sudo_user_group.conf-systemctl-daemon-reload'],
+  }
+
+  exec { '00_sssd_sudo_user_group.conf-systemctl-daemon-reload':
+    command     => 'systemctl daemon-reload',
+    refreshonly => true,
+    path        => $facts['path'],
   }
 
   service { 'sssd-sudo.socket':


### PR DESCRIPTION
The old ([camptocamp](https://forge.puppet.com/modules/camptocamp/systemd)) module is deprecated and no longer maintained.

This PR will make the [new module](https://github.com/voxpupuli/puppet-systemd/blob/master/manifests/dropin_file.pp) (maintained by voxpupuli) work by backporting the daemon reload code into this project.
