### PR TITLE
Add option to not install client tools

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Aug 27 2021 Henry Pauli <henry+spam@mixict.nl> - 7.2.0
+- Add an option in sssd::install to not install sssd client.
+  This aids in better compatibility with non RedHat based systems
+  where the ssssd-client package may not exists.
+
 * Thu Aug 05 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.1
 - Add an override for sssd-sudo.service to start it as root:root. This aligns
   with how sssd itself would start the service and the daemon cannot access

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,11 +10,15 @@
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
 class sssd::install (
-  Boolean  $install_user_tools = true,
-  String   $package_ensure     = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
+  Boolean $install_client     = true,
+  Boolean $install_user_tools = true,
+  String  $package_ensure     = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
 ) {
   assert_private()
-  include 'sssd::install::client'
+
+  if $install_client {
+    include 'sssd::install::client'
+  }
 
   package { ['sssd', 'sssd-dbus']:
     ensure => $package_ensure

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is for compatibility with debian systems where sssd-client package does not exists.

Tested on Ubuntu 20.04 and other code seems to work fine.
