### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,7 +20,9 @@ fixtures:
     simp: https://github.com/simp/pupmod-simp-simp.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     ssh: https://github.com/simp/pupmod-simp-ssh.git
-    systemd: https://github.com/simp/puppet-systemd.git
+    systemd:
+      repo: https://github.com/simp/puppet-systemd.git
+      branch: simp-master
     simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
     simp_ds389: https://github.com/simp/pupmod-simp-simp_ds389.git
     ds389: https://github.com/simp/pupmod-simp-ds389.git

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.4.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Thu May 26 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.3.0
 - Changed:
   - Made provider parameters Optional to support certain AD/realmd configurations:

--- a/manifests/service/sudo.pp
+++ b/manifests/service/sudo.pp
@@ -58,7 +58,6 @@ class sssd::service::sudo (
   systemd::dropin_file { '00_sssd_sudo_user_group.conf':
     unit                    => 'sssd-sudo.service',
     content                 => $_override_content,
-    daemon_reload           => 'eager',
     selinux_ignore_defaults => true
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",
@@ -13,8 +13,8 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -29,7 +29,7 @@ HOSTS:
       - client
       - sssdv2
     platform: el-8-x86_64
-    box: generic/centos8
+    box: centos/stream8
     hypervisor: <%= hypervisor %>
   centos7-cli:
     roles:

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -41,7 +41,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -22,7 +22,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/ad/nodesets/default.yml
+++ b/spec/acceptance/suites/ad/nodesets/default.yml
@@ -13,7 +13,6 @@ HOSTS:
     platform: windows-server-amd64
     box: devopsgroup-io/windows_server-2012r2-standard-amd64-nocm # VBOX ONLY
     hypervisor: <%= hypervisor %>
-    vagrant_memsize: 2048
     vagrant_cpus: 2
     user: vagrant
     communicator: winrm
@@ -34,7 +33,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/ad/nodesets/default.yml
+++ b/spec/acceptance/suites/ad/nodesets/default.yml
@@ -28,7 +28,7 @@ HOSTS:
     roles:
       - client
     platform: el-8-x86_64
-    box: generic/centos8
+    box: centos/stream8
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/ad/nodesets/oel.yml
+++ b/spec/acceptance/suites/ad/nodesets/oel.yml
@@ -13,7 +13,6 @@ HOSTS:
     platform: windows-server-amd64
     box: devopsgroup-io/windows_server-2012r2-standard-amd64-nocm # VBOX ONLY
     hypervisor: <%= hypervisor %>
-    vagrant_memsize: 2048
     vagrant_cpus: 2
     user: vagrant
     communicator: winrm
@@ -34,7 +33,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -53,8 +53,6 @@ describe 'sssd class' do
 
   clients.each do |client|
     context 'default parameters' do
-      os_release = fact_on(client, 'operatingsystemmajrelease')
-
       it 'manifest should work with no errors' do
         set_hieradata_on(client, default_hieradata)
         apply_manifest_on(client, manifest, :catch_failures => true)
@@ -92,6 +90,10 @@ describe 'sssd class' do
 
       it 'should get local user information' do
         on(client, 'useradd testuser --password "mypassword" -M -u 97979 -U')
+
+        # Work around bugs in sssd
+        on(client, 'getent passwd testuser')
+
         result = on(client, 'sssctl user-checks testuser').stdout
         expect(result).to match(/.*- user id: 97979.*/)
       end

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -91,8 +91,8 @@ describe 'sssd class' do
       it 'should get local user information' do
         on(client, 'useradd testuser --password "mypassword" -M -u 97979 -U')
 
-        # Work around bugs in sssd
-        on(client, 'getent passwd testuser')
+        # Allow sssd to wake up and do whatever it does :-|
+        sleep(10)
 
         result = on(client, 'sssctl user-checks testuser').stdout
         expect(result).to match(/.*- user id: 97979.*/)

--- a/spec/acceptance/suites/ds389/nodesets/default.yml
+++ b/spec/acceptance/suites/ds389/nodesets/default.yml
@@ -32,7 +32,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/ds389/nodesets/default.yml
+++ b/spec/acceptance/suites/ds389/nodesets/default.yml
@@ -11,7 +11,7 @@ HOSTS:
       - ldap
       - default
     platform: el-8-x86_64
-    box: generic/centos8
+    box: centos/stream8
     hypervisor: <%= hypervisor %>
 
   centos8.beaker:
@@ -19,7 +19,7 @@ HOSTS:
       - client
       - sssdv2
     platform: el-8-x86_64
-    box: generic/centos8
+    box: centos/stream8
     hypervisor: <%= hypervisor %>
 
   centos7.beaker:

--- a/spec/acceptance/suites/ds389/nodesets/oel.yml
+++ b/spec/acceptance/suites/ds389/nodesets/oel.yml
@@ -30,7 +30,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/ldap/nodesets/default.yml
+++ b/spec/acceptance/suites/ldap/nodesets/default.yml
@@ -23,7 +23,7 @@ HOSTS:
       - client
       - sssdv2
     platform: el-8-x86_64
-    box: generic/centos8
+    box: centos/stream8
     hypervisor: <%= hypervisor %>
   centos7:
     roles:

--- a/spec/acceptance/suites/ldap/nodesets/default.yml
+++ b/spec/acceptance/suites/ldap/nodesets/default.yml
@@ -35,7 +35,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/ldap/nodesets/oel.yml
+++ b/spec/acceptance/suites/ldap/nodesets/oel.yml
@@ -35,7 +35,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/classes/service/sudo_spec.rb
+++ b/spec/classes/service/sudo_spec.rb
@@ -15,7 +15,6 @@ describe 'sssd::service::sudo' do
             .with_content(%r(ExecStartPre=-/bin/chown sssd:sssd /var/log/sssd/sssd_sudo.log))
             .with_content(/User=root/)
             .with_content(/Group=root/)
-            .with_daemon_reload('eager')
             .with_selinux_ignore_defaults(true)
         }
         it {

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,7 +4,6 @@ require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
 
-require 'beaker/puppet_install_helper'
 require 'beaker-windows'
 include BeakerWindows::Path
 include BeakerWindows::Powershell


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829