### PR TITLE
Make `ldap_uri` parameter optional

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Aug 25 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.4.2
+  - Fixed:
+    - Made the `ldap_uri` parameter optional
+
 * Fri Jul 15 2022 Mark Fitch <mark.fitch1@hotmail.com> - 7.4.1
   - Fixed:
     - Added missing parameters `ldap_user_extra_attrs` and

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2898,7 +2898,7 @@ Default value: ``false``
 
 ##### <a name="ldap_uri"></a>`ldap_uri`
 
-Data type: `Array[Simplib::URI,1]`
+Data type: `Optional[Array[Simplib::URI,1]]`
 
 
 

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -195,7 +195,7 @@ define sssd::provider::ldap (
   Optional[Sssd::DebugLevel]            $debug_level                       = undef,
   Optional[Boolean]                     $debug_timestamps                  = undef,
   Boolean                               $debug_microseconds                = false,
-  Array[Simplib::URI,1]                 $ldap_uri                          = simplib::lookup('simp_options::ldap::uri', { 'default_value' => undef }),
+  Optional[Array[Simplib::URI,1]]       $ldap_uri                          = simplib::lookup('simp_options::ldap::uri', { 'default_value' => undef }),
   Optional[Array[Simplib::URI,1]]       $ldap_backup_uri                   = undef,
   Optional[Array[Simplib::URI,1]]       $ldap_chpass_uri                   = undef,
   Optional[Array[Simplib::URI,1]]       $ldap_chpass_backup_uri            = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",


### PR DESCRIPTION
Some customers using AD integration use the ldap provider for some of
its unique parameters but do not include `ldap_uri` because it causes
issues for them.  This patch makes this configuration possible by making
`ldap_uri` an optional parameter.