### PR TITLE
Add domain option ldap_user_search_filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Nov 29 2023 Virus2500 <_________@gmail.com> - 7.9.0
+- add domain option ldap_user_search_filter
+
 * Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 7.8.0
 - [puppetsync] Add EL9 support
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1344,6 +1344,7 @@ The following parameters are available in the `sssd::domain` defined type:
 * [`realmd_tags`](#-sssd--domain--realmd_tags)
 * [`proxy_pam_target`](#-sssd--domain--proxy_pam_target)
 * [`proxy_lib_name`](#-sssd--domain--proxy_lib_name)
+* [`ldap_user_search_filter`](#-sssd--domain--ldap_user_search_filter)
 
 ##### <a name="-sssd--domain--name"></a>`name`
 
@@ -1685,6 +1686,14 @@ Data type: `Optional[String]`
 Default value: `undef`
 
 ##### <a name="-sssd--domain--proxy_lib_name"></a>`proxy_lib_name`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+##### <a name="-sssd--domain--ldap_user_search_filter"></a>`ldap_user_search_filter`
 
 Data type: `Optional[String]`
 

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -64,6 +64,7 @@
 # @param realmd_tags
 # @param proxy_pam_target
 # @param proxy_lib_name
+# @param ldap_user_search_filter
 #
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
@@ -110,7 +111,8 @@ define sssd::domain (
   Boolean                                    $proxy_fast_alias             = false,
   Optional[String]                           $realmd_tags                  = undef,
   Optional[String]                           $proxy_pam_target             = undef,
-  Optional[String]                           $proxy_lib_name               = undef
+  Optional[String]                           $proxy_lib_name               = undef,
+  Optional[String]                           $ldap_user_search_filter      = undef
 ) {
 
   sssd::config::entry { "puppet_domain_${name}":

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/templates/domain.erb
+++ b/templates/domain.erb
@@ -98,6 +98,9 @@ proxy_fast_alias = <%= @proxy_fast_alias.to_s %>
 <% if @realmd_tags -%>
 realmd_tags = <%= @realmd_tags %>
 <% end -%>
+<% if @ldap_user_search_filter -%>
+ldap_user_search_filter = <%= @ldap_user_search_filter %>
+<% end -%>
 <% if @proxy_pam_target %>
 proxy_pam_target = <%= @proxy_pam_target %>
 <% end -%>


### PR DESCRIPTION
Hi,

just adding an simple option (ldap_user_search_filter) to the domain part. 
This option allows for example to filter out which users will be visible when running for example ```getent passwd```

br