### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -23,7 +23,6 @@ fixtures:
     systemd:
       repo: https://github.com/simp/puppet-systemd.git
       branch: simp-master
-    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
     simp_ds389: https://github.com/simp/pupmod-simp-simp_ds389.git
     ds389: https://github.com/simp/pupmod-simp-ds389.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git

--- a/spec/acceptance/suites/default/10_sssd_conf_spec.rb
+++ b/spec/acceptance/suites/default/10_sssd_conf_spec.rb
@@ -12,7 +12,6 @@ describe 'sssd' do
     'simp_options::selinux'       => true,
     'simp_options::stunnel'       => true,
     'simp_options::syslog'        => true,
-    'simp_options::tcpwrappers'   => true,
     'simp_options::ldap::uri'     => ['ldap://FIXME'],
     'simp_options::ldap::bind_dn' => 'cn=Administrator,cn=Users,dc=test,dc=case',
     'simp_options::ldap::base_dn' => 'dc=test,dc=case',

--- a/spec/acceptance/suites/ds389/templates/ds389_hiera.yaml.erb
+++ b/spec/acceptance/suites/ds389/templates/ds389_hiera.yaml.erb
@@ -8,7 +8,6 @@ simp_options::logrotate: true
 simp_options::pam: true
 simp_options::stunnel: true
 simp_options::syslog: true
-simp_options::tcpwrappers: true
 simp_options::ldap::uri: ["ldap://<%= server_fqdn %>" ]
 simp_options::ldap::bind_dn: "cn=hostAuth,ou=Hosts,<%= base_dn %>"
 simp_options::ldap::base_dn: "<%= base_dn %>"

--- a/spec/acceptance/suites/ldap/00_setup_ldap_spec.rb
+++ b/spec/acceptance/suites/ldap/00_setup_ldap_spec.rb
@@ -7,7 +7,6 @@ describe 'LDAP' do
 
   let(:server_manifest) do
     <<~EOS
-      include 'simp_openldap::server'
     EOS
   end
 

--- a/spec/acceptance/suites/ldap/templates/server_hieradata_tls.yaml.erb
+++ b/spec/acceptance/suites/ldap/templates/server_hieradata_tls.yaml.erb
@@ -2,18 +2,12 @@
 simp_options::trusted_nets:
 - 'ALL'
 simp_options::firewall: false
-simp_options::tcpwrappers: false
 simp_options::sssd: false
 simp_options::syslog: false
 simp_options::pki: true
 simp_options::pki::source: '/etc/pki/simp-testing/pki'
 
-simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
-simp_openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
 
-simp_openldap::client::app_pki_ca_dir: "%{hiera('simp_options::pki::source')}/cacerts"
-simp_openldap::client::app_pki_cert: "%{hiera('simp_options::pki::source')}/public/%{fqdn}.pub"
-simp_openldap::client::app_pki_key: "%{hiera('simp_options::pki::source')}/private/%{fqdn}.pem"
 
 simp_options::ldap::uri:
 - 'ldap://<%= server_fqdn %>'
@@ -27,4 +21,3 @@ simp_options::ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
 simp_options::ldap::root_dn: 'cn=LDAPAdmin,ou=People,<%= base_dn %>'
 simp_options::ldap::master: 'ldap://<%= server_fqdn %>'
 # suP3rP@ssw0r!
-simp_openldap::server::conf::rootpw: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.