### PR TITLE
Cleanup for 10.0.0 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 08 2026 Steven Pritchard <steve@sicura.us> - 10.0.0
+- Allow `simp-auditd` 10.x and `simp-pki` 7.x optional dependencies.
+
 * Thu Jun 18 2026 Mike Riddle <mike@sicura.us> - 9.0.1
 - Manage mode under /etc/sssd/conf.d recursively
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",
@@ -29,11 +29,11 @@
     "optional_dependencies": [
       {
         "name": "simp/auditd",
-        "version_requirement": ">= 8.5.0 < 10.0.0"
+        "version_requirement": ">= 8.5.0 < 11.0.0"
       },
       {
         "name": "simp/pki",
-        "version_requirement": ">= 6.2.0 < 7.0.0"
+        "version_requirement": ">= 6.2.0 < 8.0.0"
       }
     ]
   },


### PR DESCRIPTION
## Summary

Allow newer SIMP optional dependencies for the in-progress 9.0.0 release:

- `simp-auditd` 10.x
- `simp-pki` 7.x

## Test plan
- [x] `bundle exec rake metadata_lint` (ruby:3.2 container)