### PR TITLE
Address issues #206, #146, #115

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Thu Jul 16 2026 Nicholas Markowski <nmarkowski17.misc@gmail.com> - 10.0.0
+- Rename the ldap provider parameter `ldap_user_cert` to `ldap_user_certificate`
+  so that the value is emitted under the correct `sssd-ldap(5)` key (#206).
+  This is a breaking change for callers that set `ldap_user_cert`.
+- Add the `ldap_user_certificate` parameter to the ad provider (#206).
+- Add the `certificate_verification` parameter to the `[sssd]` section
+  via `sssd::certificate_verification` (#146).
+- Add `sssd::force_ipa_domain`, `sssd::ipa_domain_name`, and `sssd::ipa_servers`
+  so that the IPA domain can be pre-staged before the host has joined (#115).
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 9.0.2
 - Remove duplicate `@param strip_128_bit_ciphers` doc block in
   `sssd::provider::ldap` that was tripping the puppet-lint

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,7 +8,7 @@
 
 * [`sssd`](#sssd): This class allows you to install and configure SSSD.  It will forcefully disable nscd which consequently prevents you from using an nscd modu
 * [`sssd::config`](#sssd--config): Configuration class called from sssd.  Sets up the ``[sssd]`` section of '/etc/sssd/sssd.conf', and, optionally, a domain section for the IPA
-* [`sssd::config::ipa_domain`](#sssd--config--ipa_domain): Configures SSSD for the IPA domain to which the host has joined
+* [`sssd::config::ipa_domain`](#sssd--config--ipa_domain): Configures SSSD for the IPA domain to which the host has joined.  When ``sssd::force_ipa_domain`` is true, the IPA domain is configured even 
 * [`sssd::install`](#sssd--install): Install the required packages for SSSD
 * [`sssd::install::client`](#sssd--install--client): Install the sssd-client package
 * [`sssd::pki`](#sssd--pki): Class: sssd::pki  Uses the following sssd class parameters to copy certs into a directory for the sssd application  $sssd::pki   * If 'simp',
@@ -97,6 +97,7 @@ The following parameters are available in the `sssd` class:
 * [`user`](#-sssd--user)
 * [`default_domain_suffix`](#-sssd--default_domain_suffix)
 * [`override_space`](#-sssd--override_space)
+* [`certificate_verification`](#-sssd--certificate_verification)
 * [`ldap_providers`](#-sssd--ldap_providers)
 * [`enumerate_users`](#-sssd--enumerate_users)
 * [`include_svc_config`](#-sssd--include_svc_config)
@@ -107,6 +108,9 @@ The following parameters are available in the `sssd` class:
 * [`app_pki_cert_source`](#-sssd--app_pki_cert_source)
 * [`app_pki_dir`](#-sssd--app_pki_dir)
 * [`auto_add_ipa_domain`](#-sssd--auto_add_ipa_domain)
+* [`force_ipa_domain`](#-sssd--force_ipa_domain)
+* [`ipa_domain_name`](#-sssd--ipa_domain_name)
+* [`ipa_servers`](#-sssd--ipa_servers)
 * [`custom_config`](#-sssd--custom_config)
 
 ##### <a name="-sssd--authoritative"></a>`authoritative`
@@ -245,6 +249,17 @@ Data type: `Optional[String[1]]`
 
 Default value: `undef`
 
+##### <a name="-sssd--certificate_verification"></a>`certificate_verification`
+
+Data type: `Optional[String[1]]`
+
+Value of the ``certificate_verification`` option written to the ``[sssd]``
+section.  Used to tune OCSP/CRL behavior for smartcard authentication.
+Accepts a comma-separated list of tokens (e.g., ``ocsp_dgst=sha1, no_ocsp``)
+per ``sssd.conf(5)``.
+
+Default value: `undef`
+
 ##### <a name="-sssd--ldap_providers"></a>`ldap_providers`
 
 Data type: `Hash`
@@ -350,6 +365,37 @@ configure the IPA domain yourself.
 
 Default value: `true`
 
+##### <a name="-sssd--force_ipa_domain"></a>`force_ipa_domain`
+
+Data type: `Boolean`
+
+Configure sssd for the IPA domain even when the ``ipa`` fact reports
+``connected => false`` (or is absent).  Useful when pre-staging
+configuration before the host has actually joined the realm.
+
+* When the ``ipa`` fact is missing or incomplete, ``ipa_domain_name``
+  and ``ipa_servers`` must be supplied.
+
+Default value: `false`
+
+##### <a name="-sssd--ipa_domain_name"></a>`ipa_domain_name`
+
+Data type: `Optional[String[1]]`
+
+The IPA domain name to use when ``force_ipa_domain`` is enabled and
+``$facts['ipa']['domain']`` is not available.
+
+Default value: `undef`
+
+##### <a name="-sssd--ipa_servers"></a>`ipa_servers`
+
+Data type: `Optional[Array[Simplib::Hostname,1]]`
+
+The IPA servers to use when ``force_ipa_domain`` is enabled and
+``$facts['ipa']['server']`` is not available.
+
+Default value: `undef`
+
 ##### <a name="-sssd--custom_config"></a>`custom_config`
 
 Data type: `Optional[String[1]]`
@@ -415,7 +461,12 @@ Default value: `{ 'owner' => 'root', 'group' => 'sssd', 'mode' => '0640' }`
 
 ### <a name="sssd--config--ipa_domain"></a>`sssd::config::ipa_domain`
 
-Configures SSSD for the IPA domain to which the host has joined
+Configures SSSD for the IPA domain to which the host has joined.
+
+When ``sssd::force_ipa_domain`` is true, the IPA domain is configured even
+if the ``ipa`` fact reports ``connected => false`` or is missing entirely.
+In that case ``sssd::ipa_domain_name`` and ``sssd::ipa_servers`` are used
+to fill in any values the fact does not provide.
 
 ### <a name="sssd--install"></a>`sssd::install`
 
@@ -1849,6 +1900,7 @@ The following parameters are available in the `sssd::provider::ad` defined type:
 * [`ldap_use_tokengroups`](#-sssd--provider--ad--ldap_use_tokengroups)
 * [`ldap_group_objectsid`](#-sssd--provider--ad--ldap_group_objectsid)
 * [`ldap_user_objectsid`](#-sssd--provider--ad--ldap_user_objectsid)
+* [`ldap_user_certificate`](#-sssd--provider--ad--ldap_user_certificate)
 * [`ldap_user_extra_attrs`](#-sssd--provider--ad--ldap_user_extra_attrs)
 * [`ldap_user_ssh_public_key`](#-sssd--provider--ad--ldap_user_ssh_public_key)
 
@@ -2259,6 +2311,14 @@ Default value: `undef`
 Data type: `Optional[String[1]]`
 
 
+
+Default value: `undef`
+
+##### <a name="-sssd--provider--ad--ldap_user_certificate"></a>`ldap_user_certificate`
+
+Data type: `Optional[String[1]]`
+
+The LDAP attribute that holds the user certificate used for smartcard authentication.
 
 Default value: `undef`
 
@@ -2820,7 +2880,7 @@ The following parameters are available in the `sssd::provider::ldap` defined typ
 * [`ldap_default_bind_dn`](#-sssd--provider--ldap--ldap_default_bind_dn)
 * [`ldap_default_authtok_type`](#-sssd--provider--ldap--ldap_default_authtok_type)
 * [`ldap_default_authtok`](#-sssd--provider--ldap--ldap_default_authtok)
-* [`ldap_user_cert`](#-sssd--provider--ldap--ldap_user_cert)
+* [`ldap_user_certificate`](#-sssd--provider--ldap--ldap_user_certificate)
 * [`ldap_user_object_class`](#-sssd--provider--ldap--ldap_user_object_class)
 * [`ldap_user_name`](#-sssd--provider--ldap--ldap_user_name)
 * [`ldap_user_uid_number`](#-sssd--provider--ldap--ldap_user_uid_number)
@@ -3078,7 +3138,7 @@ Data type: `Optional[String[1]]`
 
 Default value: `simplib::lookup('simp_options::ldap::bind_pw', { 'default_value' => undef })`
 
-##### <a name="-sssd--provider--ldap--ldap_user_cert"></a>`ldap_user_cert`
+##### <a name="-sssd--provider--ldap--ldap_user_certificate"></a>`ldap_user_certificate`
 
 Data type: `Optional[String[1]]`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -389,7 +389,7 @@ Default value: `undef`
 
 ##### <a name="-sssd--ipa_servers"></a>`ipa_servers`
 
-Data type: `Optional[Array[Simplib::Hostname,1]]`
+Data type: `Optional[Array[Simplib::Host,1]]`
 
 The IPA servers to use when ``force_ipa_domain`` is enabled and
 ``$facts['ipa']['server']`` is not available.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,12 +34,12 @@ class sssd::config (
 
   include $module_name
 
-  if $sssd::auto_add_ipa_domain and ($facts['ipa'] or $sssd::force_ipa_domain) {
+  if $sssd::auto_add_ipa_domain and ($facts.dig('ipa', 'connected') or $sssd::force_ipa_domain) {
     # this host has joined an IPA domain, or the operator is forcing the
     # IPA domain to be configured ahead of the join
     $_ipa_domain_name = pick_default($facts.dig('ipa', 'domain'), $sssd::ipa_domain_name)
     if empty($_ipa_domain_name) {
-      fail('sssd::ipa_domain_name must be set when sssd::force_ipa_domain is true and the ipa fact is unavailable')
+      fail('The IPA domain must be provided by the ipa fact or set via sssd::ipa_domain_name')
     }
     $_domains = unique(concat($sssd::domains, $_ipa_domain_name))
     include 'sssd::config::ipa_domain'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,9 +34,14 @@ class sssd::config (
 
   include $module_name
 
-  if ($sssd::auto_add_ipa_domain and $facts['ipa']) {
-    # this host has joined an IPA domain
-    $_domains = unique(concat($sssd::domains, $facts['ipa']['domain']))
+  if $sssd::auto_add_ipa_domain and ($facts['ipa'] or $sssd::force_ipa_domain) {
+    # this host has joined an IPA domain, or the operator is forcing the
+    # IPA domain to be configured ahead of the join
+    $_ipa_domain_name = pick_default($facts.dig('ipa', 'domain'), $sssd::ipa_domain_name)
+    if empty($_ipa_domain_name) {
+      fail('sssd::ipa_domain_name must be set when sssd::force_ipa_domain is true and the ipa fact is unavailable')
+    }
+    $_domains = unique(concat($sssd::domains, $_ipa_domain_name))
     include 'sssd::config::ipa_domain'
   }
   else {
@@ -56,8 +61,9 @@ class sssd::config (
   $_try_inotify           = $sssd::try_inotify
   $_krb5_rcache_dir       = $sssd::krb5_rcache_dir
   $_user                  = $sssd::user
-  $_default_domain_suffix = $sssd::default_domain_suffix
-  $_override_space        = $sssd::override_space
+  $_default_domain_suffix    = $sssd::default_domain_suffix
+  $_override_space           = $sssd::override_space
+  $_certificate_verification = $sssd::certificate_verification
 
   if $sssd::include_svc_config {
     $_services.each | $service | {
@@ -115,6 +121,7 @@ class sssd::config (
   $user_line = $_user ? { undef => [], default => ["user = ${_user}"] }
   $default_domain_suffix_line = $_default_domain_suffix ? { undef => [], default => ["default_domain_suffix = ${_default_domain_suffix}"] }
   $override_space_line = $_override_space ? { undef => [], default => ["override_space = ${_override_space}"] }
+  $certificate_verification_line = $_certificate_verification ? { undef => [], default => ["certificate_verification = ${_certificate_verification}"] }
 
   # Debug configuration
   $debug_level_line = $_debug_level ? { undef => [], default => ["debug_level = ${_debug_level}"] }
@@ -135,6 +142,7 @@ class sssd::config (
     $user_line +
     $default_domain_suffix_line +
     $override_space_line +
+    $certificate_verification_line +
     $enable_files_domain_line +
     $debug_level_line +
     $debug_timestamps_line +

--- a/manifests/config/ipa_domain.pp
+++ b/manifests/config/ipa_domain.pp
@@ -1,12 +1,24 @@
-# Configures SSSD for the IPA domain to which the host has joined
+# Configures SSSD for the IPA domain to which the host has joined.
+#
+# When ``sssd::force_ipa_domain`` is true, the IPA domain is configured even
+# if the ``ipa`` fact reports ``connected => false`` or is missing entirely.
+# In that case ``sssd::ipa_domain_name`` and ``sssd::ipa_servers`` are used
+# to fill in any values the fact does not provide.
 #
 class sssd::config::ipa_domain {
   assert_private()
 
-  if $facts.dig('ipa', 'connected') {
-    # this host has joined an IPA domain
-    $_ipa_domain = $facts['ipa']['domain']
-    $_ipa_server = $facts['ipa']['server']
+  if $facts.dig('ipa', 'connected') or $sssd::force_ipa_domain {
+    $_ipa_domain = pick_default($facts.dig('ipa', 'domain'), $sssd::ipa_domain_name)
+    $_fact_server = $facts.dig('ipa', 'server')
+    $_ipa_servers = $_fact_server ? {
+      undef   => $sssd::ipa_servers,
+      default => [$_fact_server],
+    }
+
+    if empty($_ipa_domain) or empty($_ipa_servers) {
+      fail('sssd::ipa_domain_name and sssd::ipa_servers must be set when sssd::force_ipa_domain is true and the ipa fact does not provide them')
+    }
 
     sssd::domain { $_ipa_domain:
       description       => "IPA Domain ${_ipa_domain}",
@@ -23,7 +35,7 @@ class sssd::config::ipa_domain {
 
     sssd::provider::ipa { $_ipa_domain:
       ipa_domain => $_ipa_domain,
-      ipa_server => [$_ipa_server],
+      ipa_server => $_ipa_servers,
     }
   }
 }

--- a/manifests/config/ipa_domain.pp
+++ b/manifests/config/ipa_domain.pp
@@ -17,7 +17,7 @@ class sssd::config::ipa_domain {
     }
 
     if empty($_ipa_domain) or empty($_ipa_servers) {
-      fail('sssd::ipa_domain_name and sssd::ipa_servers must be set when sssd::force_ipa_domain is true and the ipa fact does not provide them')
+      fail('The IPA domain and server(s) must be provided by the ipa fact or set via sssd::ipa_domain_name and sssd::ipa_servers')
     }
 
     sssd::domain { $_ipa_domain:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,11 @@
 # @param user
 # @param default_domain_suffix
 # @param override_space
+# @param certificate_verification
+#   Value of the ``certificate_verification`` option written to the ``[sssd]``
+#   section.  Used to tune OCSP/CRL behavior for smartcard authentication.
+#   Accepts a comma-separated list of tokens (e.g., ``ocsp_dgst=sha1, no_ocsp``)
+#   per ``sssd.conf(5)``.
 # @param ldap_providers
 #   This allows users to set up ldap sssd::provider::ldap resources via hieradata
 # @example sssd::provider::ldap in hieradata:
@@ -87,6 +92,22 @@
 #   lockout for IPA-managed user accounts.  Otherwise, you must
 #   configure the IPA domain yourself.
 #
+# @param force_ipa_domain
+#   Configure sssd for the IPA domain even when the ``ipa`` fact reports
+#   ``connected => false`` (or is absent).  Useful when pre-staging
+#   configuration before the host has actually joined the realm.
+#
+#   * When the ``ipa`` fact is missing or incomplete, ``ipa_domain_name``
+#     and ``ipa_servers`` must be supplied.
+#
+# @param ipa_domain_name
+#   The IPA domain name to use when ``force_ipa_domain`` is enabled and
+#   ``$facts['ipa']['domain']`` is not available.
+#
+# @param ipa_servers
+#   The IPA servers to use when ``force_ipa_domain`` is enabled and
+#   ``$facts['ipa']['server']`` is not available.
+#
 # @param custom_config
 #   A configuration that will be added to
 #   /etc/sssd/conf.d/00_puppet_custom.conf *without validation*
@@ -110,6 +131,7 @@ class sssd (
   Optional[String[1]]           $user                  = undef,
   Optional[String[1]]           $default_domain_suffix = undef,
   Optional[String[1]]           $override_space        = undef,
+  Optional[String[1]]           $certificate_verification = undef,
   Hash                          $ldap_providers        = {},
   Boolean                       $enable_files_domain   = true,
   Boolean                       $enumerate_users       = false,
@@ -121,6 +143,9 @@ class sssd (
   Stdlib::Absolutepath          $app_pki_cert_source   = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath          $app_pki_dir           = '/etc/pki/simp_apps/sssd/x509',
   Boolean                       $auto_add_ipa_domain   = true,
+  Boolean                       $force_ipa_domain      = false,
+  Optional[String[1]]           $ipa_domain_name       = undef,
+  Optional[Array[Simplib::Hostname,1]] $ipa_servers     = undef,
   Optional[String[1]]           $custom_config         = undef,
 ) {
   include 'sssd::install'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,7 +145,7 @@ class sssd (
   Boolean                       $auto_add_ipa_domain   = true,
   Boolean                       $force_ipa_domain      = false,
   Optional[String[1]]           $ipa_domain_name       = undef,
-  Optional[Array[Simplib::Hostname,1]] $ipa_servers     = undef,
+  Optional[Array[Simplib::Host,1]] $ipa_servers         = undef,
   Optional[String[1]]           $custom_config         = undef,
 ) {
   include 'sssd::install'

--- a/manifests/provider/ad.pp
+++ b/manifests/provider/ad.pp
@@ -85,6 +85,8 @@
 # @param ldap_use_tokengroups
 # @param ldap_group_objectsid
 # @param ldap_user_objectsid
+# @param ldap_user_certificate
+#   The LDAP attribute that holds the user certificate used for smartcard authentication.
 # @param ldap_user_extra_attrs
 #   Can be used to enable public key storage for ssh
 #   When used this way, set this param and param ldap_user_ssh_public_key
@@ -147,6 +149,7 @@ define sssd::provider::ad (
   Boolean                                                    $ldap_use_tokengroups                     = true,
   Optional[String[1]]                                        $ldap_group_objectsid                     = undef,
   Optional[String[1]]                                        $ldap_user_objectsid                      = undef,
+  Optional[String[1]]                                        $ldap_user_certificate                    = undef,
   Optional[String[1]]                                        $ldap_user_extra_attrs                    = undef,
   Optional[String[1]]                                        $ldap_user_ssh_public_key                 = undef,
 ) {
@@ -195,6 +198,7 @@ define sssd::provider::ad (
     'ldap_use_tokengroups'                     => $ldap_use_tokengroups,
     'ldap_group_objectsid'                     => $ldap_group_objectsid,
     'ldap_user_objectsid'                      => $ldap_user_objectsid,
+    'ldap_user_certificate'                    => $ldap_user_certificate,
     'ldap_user_extra_attrs'                    => $ldap_user_extra_attrs,
     'ldap_user_ssh_public_key'                 => $ldap_user_ssh_public_key,
   }
@@ -280,6 +284,7 @@ define sssd::provider::ad (
   $ldap_use_tokengroups_line = ["ldap_use_tokengroups = ${ldap_use_tokengroups}"]
   $ldap_group_objectsid_line = $ldap_group_objectsid ? { undef => [], default => ["ldap_group_objectsid = ${ldap_group_objectsid}"] }
   $ldap_user_objectsid_line = $ldap_user_objectsid ? { undef => [], default => ["ldap_user_objectsid = ${ldap_user_objectsid}"] }
+  $ldap_user_certificate_line = $ldap_user_certificate ? { undef => [], default => ["ldap_user_certificate = ${ldap_user_certificate}"] }
   $ldap_user_extra_attrs_line = $ldap_user_extra_attrs ? { undef => [], default => ["ldap_user_extra_attrs = ${ldap_user_extra_attrs}"] }
   $ldap_user_ssh_public_key_line = $ldap_user_ssh_public_key ? { undef => [], default => ["ldap_user_ssh_public_key = ${ldap_user_ssh_public_key}"] }
 
@@ -322,6 +327,7 @@ define sssd::provider::ad (
     $ldap_use_tokengroups_line +
     $ldap_group_objectsid_line +
     $ldap_user_objectsid_line +
+    $ldap_user_certificate_line +
     $ldap_user_extra_attrs_line +
     $ldap_user_ssh_public_key_line
   )

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -52,7 +52,7 @@
 # @param ldap_default_bind_dn
 # @param ldap_default_authtok_type
 # @param ldap_default_authtok
-# @param ldap_user_cert
+# @param ldap_user_certificate
 # @param ldap_user_object_class
 # @param ldap_user_name
 # @param ldap_user_uid_number
@@ -208,7 +208,7 @@ define sssd::provider::ldap (
   Optional[String[1]]                   $ldap_default_bind_dn              = simplib::lookup('simp_options::ldap::bind_dn', { 'default_value' => undef }),
   Optional[Sssd::LdapDefaultAuthtok]    $ldap_default_authtok_type         = undef,
   Optional[String[1]]                   $ldap_default_authtok              = simplib::lookup('simp_options::ldap::bind_pw', { 'default_value' => undef }),
-  Optional[String[1]]                   $ldap_user_cert                    = undef,
+  Optional[String[1]]                   $ldap_user_certificate             = undef,
   Optional[String[1]]                   $ldap_user_object_class            = undef,
   Optional[String[1]]                   $ldap_user_name                    = undef,
   Optional[String[1]]                   $ldap_user_uid_number              = undef,
@@ -398,7 +398,7 @@ define sssd::provider::ldap (
     'ldap_default_bind_dn',
     'ldap_default_authtok_type',
     'ldap_default_authtok',
-    'ldap_user_cert',
+    'ldap_user_certificate',
     'ldap_user_object_class',
     'ldap_user_name',
     'ldap_user_uid_number',
@@ -544,7 +544,7 @@ define sssd::provider::ldap (
     'ldap_default_bind_dn'                       => $ldap_default_bind_dn,
     'ldap_default_authtok_type'                  => $ldap_default_authtok_type,
     'ldap_default_authtok'                       => $ldap_default_authtok,
-    'ldap_user_cert'                             => $ldap_user_cert,
+    'ldap_user_certificate'                      => $ldap_user_certificate,
     'ldap_user_object_class'                     => $ldap_user_object_class,
     'ldap_user_name'                             => $ldap_user_name,
     'ldap_user_uid_number'                       => $ldap_user_uid_number,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "9.0.2",
+  "version": "10.0.0",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/spec/classes/config/ipa_domain_spec.rb
+++ b/spec/classes/config/ipa_domain_spec.rb
@@ -64,6 +64,75 @@ describe 'sssd::config::ipa_domain' do
           it { is_expected.not_to contain_sssd__domain('ipa.example.com') }
           it { is_expected.not_to contain_sssd__provider__ipa('ipa.example.com') }
         end
+
+        context 'when forcing the IPA domain with the ipa fact present but not connected' do
+          let(:pre_condition) do
+            <<~PRECOND
+              function assert_private {}
+              class { 'sssd':
+                force_ipa_domain => true,
+                ipa_servers      => ['fallback.ipa.example.com'],
+              }
+            PRECOND
+          end
+
+          let(:facts) do
+            os_facts.merge(
+              ipa: {
+                basedn: 'dc=example,dc=com',
+                domain: 'ipa.example.com',
+                realm: 'EXAMPLE.COM',
+                connected: false,
+              },
+            )
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to contain_sssd__domain('ipa.example.com')
+              .with_id_provider('ipa')
+          end
+          it do
+            is_expected.to contain_sssd__provider__ipa('ipa.example.com')
+              .with_ipa_domain('ipa.example.com')
+              .with_ipa_server(['fallback.ipa.example.com'])
+          end
+        end
+
+        context 'when forcing the IPA domain with no ipa fact and override params' do
+          let(:pre_condition) do
+            <<~PRECOND
+              function assert_private {}
+              class { 'sssd':
+                force_ipa_domain => true,
+                ipa_domain_name  => 'staged.example.com',
+                ipa_servers      => ['ipa1.example.com', 'ipa2.example.com'],
+              }
+            PRECOND
+          end
+          let(:facts) { os_facts }
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to contain_sssd__provider__ipa('staged.example.com')
+              .with_ipa_domain('staged.example.com')
+              .with_ipa_server(['ipa1.example.com', 'ipa2.example.com'])
+          end
+        end
+
+        context 'when forcing the IPA domain without enough information' do
+          let(:pre_condition) do
+            <<~PRECOND
+              function assert_private {}
+              class { 'sssd':
+                force_ipa_domain => true,
+              }
+            PRECOND
+          end
+          let(:facts) { os_facts }
+
+          it { is_expected.to compile.and_raise_error(%r{sssd::ipa_domain_name must be set}) }
+        end
       end
     end
   end

--- a/spec/classes/config/ipa_domain_spec.rb
+++ b/spec/classes/config/ipa_domain_spec.rb
@@ -131,7 +131,7 @@ describe 'sssd::config::ipa_domain' do
           end
           let(:facts) { os_facts }
 
-          it { is_expected.to compile.and_raise_error(%r{sssd::ipa_domain_name must be set}) }
+          it { is_expected.to compile.and_raise_error(%r{The IPA domain must be provided}) }
         end
       end
     end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -114,6 +114,7 @@ describe 'sssd' do
               user: 'sssduser',
               default_domain_suffix: 'example.com',
               override_space: '__',
+              certificate_verification: 'ocsp_dgst=sha1, no_ocsp',
             }
           end
 
@@ -132,6 +133,7 @@ describe 'sssd' do
             user = sssduser
             default_domain_suffix = example.com
             override_space = __
+            certificate_verification = ocsp_dgst=sha1, no_ocsp
             enable_files_domain = false
             debug_level = 3
             debug_timestamps = true

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -53,6 +53,7 @@ describe 'sssd' do
   let(:ipa_fact_joined) do
     {
       ipa: {
+        connected: true,
         domain: 'ipa.example.com',
         server: 'ipaserver.example.com',
       },
@@ -97,6 +98,24 @@ describe 'sssd' do
 
             it_behaves_like 'a sssd::config', default_content_with_domains.gsub('FILE, LDAP', 'FILE, LDAP, ipa.example.com')
             it { is_expected.to contain_class('sssd::config::ipa_domain') }
+          end
+
+          context 'with the ipa fact present but not connected' do
+            let(:facts) do
+              os_facts.merge(
+                ipa: {
+                  domain: 'ipa.example.com',
+                  server: 'ipaserver.example.com',
+                  connected: false,
+                },
+              )
+            end
+
+            # The domain must not be added to the domains list nor
+            # sssd::config::ipa_domain included, otherwise sssd.conf would
+            # reference an unconfigured domain.
+            it_behaves_like 'a sssd::config', default_content_with_domains
+            it { is_expected.not_to contain_class('sssd::config::ipa_domain') }
           end
         end
 

--- a/spec/defines/provider/ad_spec.rb
+++ b/spec/defines/provider/ad_spec.rb
@@ -104,6 +104,7 @@ describe 'sssd::provider::ad' do
             ldap_idmap_helper_table_size: 8,
             ldap_group_objectsid: 'my_ldap_group_objectsid',
             ldap_user_objectsid: 'my_ldap_user_objectsid',
+            ldap_user_certificate: 'userCertificate;binary',
             ldap_user_extra_attrs: 'altSecurityIdentities',
             ldap_user_ssh_public_key: 'altSecurityIdentities',
           }
@@ -161,6 +162,7 @@ describe 'sssd::provider::ad' do
             ldap_use_tokengroups = true
             ldap_group_objectsid = my_ldap_group_objectsid
             ldap_user_objectsid = my_ldap_user_objectsid
+            ldap_user_certificate = userCertificate;binary
             ldap_user_extra_attrs = altSecurityIdentities
             ldap_user_ssh_public_key = altSecurityIdentities
           EXPECTED

--- a/spec/defines/provider/ldap_spec.rb
+++ b/spec/defines/provider/ldap_spec.rb
@@ -105,13 +105,13 @@ describe 'sssd::provider::ldap' do
         end
       end
 
-      context 'with ldap_user_cert set' do
-        let(:params) { { ldap_user_cert: 'userCertificate;binary' } }
+      context 'with ldap_user_certificate set' do
+        let(:params) { { ldap_user_certificate: 'userCertificate;binary' } }
 
         it { is_expected.to compile.with_all_deps }
         it {
           is_expected.to create_sssd__config__entry("puppet_provider_#{title}_ldap")
-            .with_content(%r{ldap_user_cert = userCertificate;binary})
+            .with_content(%r{ldap_user_certificate = userCertificate;binary})
         }
       end
 


### PR DESCRIPTION
- Rename ldap provider parameter `ldap_user_cert` to `ldap_user_certificate` so the value is emitted under the correct sssd-ldap(5) key, and add the same parameter to the ad provider (#206). The ldap rename is a breaking change for any caller that sets `ldap_user_cert`.
- Add `sssd::certificate_verification`, written to the `[sssd]` section so smartcard OCSP/CRL behavior can be tuned via the module (#146).
- Add `sssd::force_ipa_domain`, `sssd::ipa_domain_name`, and `sssd::ipa_servers` so the IPA domain can be pre-staged before the host has joined the realm (#115). When forced, missing fields in the `ipa` fact are filled from the new parameters.