### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -31,6 +31,22 @@ describe 'sssd class' do
   end
 
   clients.each do |client|
+    # Exercise noop from a clean (uninstalled) state: on a fresh node the Sicura
+    # console previews the module with `puppet apply --noop`, which must not error
+    # even though nothing sssd manages exists yet. Real idempotence is covered
+    # by the applies below. A post-convergence noop check is deliberately omitted:
+    # `puppet apply --noop --detailed-exitcodes` always exits 0, so it could never
+    # fail and would test nothing.
+    context 'in noop mode from a clean state' do
+      before(:context) do
+        on(client, 'puppet resource package sssd ensure=absent')
+      end
+
+      it 'applies without errors in noop mode' do
+        apply_manifest_on(client, manifest, catch_failures: true, noop: true)
+      end
+    end
+
     context 'default parameters' do
       it 'manifest should work with no errors' do
         set_hieradata_on(client, default_hieradata)


### PR DESCRIPTION
Adds an acceptance example that applies the module under `puppet apply --noop` from a fresh, uninstalled node — mirroring the preview the Sicura console runs on a clean host — and asserts it completes without error. It reuses the suite's existing default manifest so the check stays representative of the module's real default, and deliberately omits a post-convergence noop check (`--noop --detailed-exitcodes` always exits 0, so it would test nothing).