### PR TITLE
Add AlmaLinux 8 to the CI beaker acceptance matrix

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -129,6 +129,7 @@ jobs:
     strategy:
       matrix:
         node:
+          - almalinux8
           - almalinux9
           - almalinux10
       fail-fast: false


### PR DESCRIPTION
### What this does

Adds `almalinux8` to the acceptance job matrix in `pr_tests.yml`, so the default beaker suite runs on AlmaLinux 8, 9, and 10.

### Notes

- The module already supports EL8 (`metadata.json`) and `spec/acceptance/nodesets/almalinux8.yml` already exists — CI just wasn't exercising it.
- Runner resources are not a concern: each matrix entry is a separate job on its own `ubuntu-latest` runner (4 vCPU / 16 GB), and each nodeset is a single 2 GB libvirt VM. This adds a third parallel job, not a third VM on one runner.
- This PR's own CI run demonstrates the new job passing.
- `pr_tests.yml` carries the puppetsync-managed header, but the acceptance job only exists in the deployed per-repo copies (the puppetsync template has no acceptance job), so this is a repo-level change consistent with how the matrix got here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)