### PR TITLE
Support multiple/backup krb5 servers in sssd::provider::krb5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Wed Jul 29 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 10.1.0
+- Support multiple servers and a backup server in `sssd::provider::krb5`:
+  `krb5_server` now accepts one or more hosts (optionally `host:port`), and a
+  new `krb5_backup_server` parameter was added. Both render as comma-separated
+  lists.
+- Add the `Sssd::Krb5Server` type and use it for the `krb5_server` /
+  `krb5_backup_server` parameters of both `sssd::provider::krb5` and
+  `sssd::provider::ldap`, harmonizing their types.
+
 * Thu Jul 16 2026 Nicholas Markowski <nmarkowski17.misc@gmail.com> - 10.0.0
 - Rename the ldap provider parameter `ldap_user_cert` to `ldap_user_certificate`
   so that the value is emitted under the correct `sssd-ldap(5)` key (#206).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -43,6 +43,7 @@
 * [`Sssd::ChpassProvider`](#Sssd--ChpassProvider): List of valid types for sssd domain change password provider
 * [`Sssd::DebugLevel`](#Sssd--DebugLevel): Integer[0-9] or 2 byte Hexidecimal (ex. 0x0201)
 * [`Sssd::IdProvider`](#Sssd--IdProvider): List of valid type for sssd domain ID provider.
+* [`Sssd::Krb5Server`](#Sssd--Krb5Server): Valid `krb5_server`/`krb5_backup_server` value: a single host (optionally with a port), or a non-empty array of them. Rendered as a comma-sep
 * [`Sssd::LdapAccessOrder`](#Sssd--LdapAccessOrder): List of valid values for ldap provider ldap_access_order setting
 * [`Sssd::LdapAccountExpirePol`](#Sssd--LdapAccountExpirePol): List of valid values for ldap provider ldap_account_expire_policy '' corresponds to the default value (empty) per sssd-ldap(5) man page
 * [`Sssd::LdapDefaultAuthtok`](#Sssd--LdapDefaultAuthtok): List of valid values for ldap provider default auth token
@@ -2678,6 +2679,7 @@ The following parameters are available in the `sssd::provider::krb5` defined typ
 
 * [`name`](#-sssd--provider--krb5--name)
 * [`krb5_server`](#-sssd--provider--krb5--krb5_server)
+* [`krb5_backup_server`](#-sssd--provider--krb5--krb5_backup_server)
 * [`krb5_realm`](#-sssd--provider--krb5--krb5_realm)
 * [`debug_level`](#-sssd--provider--krb5--debug_level)
 * [`debug_timestamps`](#-sssd--provider--krb5--debug_timestamps)
@@ -2700,9 +2702,19 @@ The name of the associated domain section in the configuration file.
 
 ##### <a name="-sssd--provider--krb5--krb5_server"></a>`krb5_server`
 
-Data type: `Optional[Simplib::Host]`
+Data type: `Optional[Sssd::Krb5Server]`
 
+One or more KDCs (optionally `host:port`). Rendered as a comma-separated
+`krb5_server` list.
 
+Default value: `undef`
+
+##### <a name="-sssd--provider--krb5--krb5_backup_server"></a>`krb5_backup_server`
+
+Data type: `Optional[Sssd::Krb5Server]`
+
+One or more backup KDCs (optionally `host:port`). Rendered as a
+comma-separated `krb5_backup_server` list.
 
 Default value: `undef`
 
@@ -3812,7 +3824,7 @@ Default value: `undef`
 
 ##### <a name="-sssd--provider--ldap--krb5_server"></a>`krb5_server`
 
-Data type: `Optional[Array[String[1],1]]`
+Data type: `Optional[Sssd::Krb5Server]`
 
 
 
@@ -3820,7 +3832,7 @@ Default value: `undef`
 
 ##### <a name="-sssd--provider--ldap--krb5_backup_server"></a>`krb5_backup_server`
 
-Data type: `Optional[Array[String[1],1]]`
+Data type: `Optional[Sssd::Krb5Server]`
 
 
 
@@ -4260,6 +4272,14 @@ Alias of `Variant[Integer[0,9], Pattern[/0x\h{4}$/]]`
 List of valid type for sssd domain ID provider.
 
 Alias of `Enum['proxy', 'ldap', 'ipa', 'ad', 'files']`
+
+### <a name="Sssd--Krb5Server"></a>`Sssd::Krb5Server`
+
+Valid `krb5_server`/`krb5_backup_server` value: a single host (optionally
+with a port), or a non-empty array of them. Rendered as a comma-separated
+list in the SSSD configuration.
+
+Alias of `Variant[Simplib::Host, Simplib::Host::Port, Array[Variant[Simplib::Host, Simplib::Host::Port], 1]]`
 
 ### <a name="Sssd--LdapAccessOrder"></a>`Sssd::LdapAccessOrder`
 

--- a/manifests/provider/krb5.pp
+++ b/manifests/provider/krb5.pp
@@ -9,6 +9,11 @@
 #   The name of the associated domain section in the configuration file.
 #
 # @param krb5_server
+#   One or more KDCs (optionally `host:port`). Rendered as a comma-separated
+#   `krb5_server` list.
+# @param krb5_backup_server
+#   One or more backup KDCs (optionally `host:port`). Rendered as a
+#   comma-separated `krb5_backup_server` list.
 # @param krb5_realm
 # @param debug_level
 # @param debug_timestamps
@@ -29,7 +34,8 @@
 #
 define sssd::provider::krb5 (
   String                                 $krb5_realm,
-  Optional[Simplib::Host]                $krb5_server                    = undef,
+  Optional[Sssd::Krb5Server]             $krb5_server                    = undef,
+  Optional[Sssd::Krb5Server]             $krb5_backup_server             = undef,
   Optional[Sssd::DebugLevel]             $debug_level                    = undef,
   Boolean                                $debug_timestamps               = true,
   Boolean                                $debug_microseconds             = false,
@@ -51,8 +57,12 @@ define sssd::provider::krb5 (
   $debug_timestamps_line = ["debug_timestamps = ${debug_timestamps}"]
   $debug_microseconds_line = ["debug_microseconds = ${debug_microseconds}"]
 
-  # Kerberos server settings
-  $krb5_server_line = $krb5_server ? { undef => [], default => ["krb5_server = ${krb5_server}"] }
+  # Kerberos server settings (accept a single host or an array; render as a
+  # comma-separated list)
+  $_krb5_servers = [$krb5_server].flatten
+  $_krb5_backup_servers = [$krb5_backup_server].flatten
+  $krb5_server_line = $krb5_server ? { undef => [], default => ["krb5_server = ${_krb5_servers.join(',')}"] }
+  $krb5_backup_server_line = $krb5_backup_server ? { undef => [], default => ["krb5_backup_server = ${_krb5_backup_servers.join(',')}"] }
   $krb5_realm_line = ["krb5_realm = ${krb5_realm}"]
   $krb5_kpasswd_line = $krb5_kpasswd ? { undef => [], default => ["krb5_kpasswd = ${krb5_kpasswd}"] }
 
@@ -80,6 +90,7 @@ define sssd::provider::krb5 (
     $debug_timestamps_line +
     $debug_microseconds_line +
     $krb5_server_line +
+    $krb5_backup_server_line +
     $krb5_realm_line +
     $krb5_kpasswd_line +
     $krb5_ccachedir_line +

--- a/manifests/provider/ldap.pp
+++ b/manifests/provider/ldap.pp
@@ -293,8 +293,8 @@ define sssd::provider::ldap (
   Optional[Stdlib::Absolutepath]        $ldap_krb5_keytab                  = undef,
   Boolean                               $ldap_krb5_init_creds              = true,
   Optional[Integer]                     $ldap_krb5_ticket_lifetime         = undef,
-  Optional[Array[String[1],1]]          $krb5_server                       = undef,
-  Optional[Array[String[1],1]]          $krb5_backup_server                = undef,
+  Optional[Sssd::Krb5Server]            $krb5_server                       = undef,
+  Optional[Sssd::Krb5Server]            $krb5_backup_server                = undef,
   Optional[String[1]]                   $krb5_realm                        = undef,
   Boolean                               $krb5_canonicalize                 = false,
   Boolean                               $krb5_use_kdcinfo                  = true,
@@ -703,7 +703,10 @@ define sssd::provider::ldap (
   $array_config_lines = $array_params.filter |$param, $config| {
     $config['value'] != undef and !$config['value'].empty
   }.map |$param, $config| {
-    "${param} = ${Array($config['value']).unique.join($config['separator'])}"
+    # flatten to accept a single value or an array without splitting a single
+    # string into characters (which Array() would do)
+    $_values = [$config['value']].flatten.unique
+    "${param} = ${_values.join($config['separator'])}"
   }
 
   # Combine all configuration lines and sort them

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sssd",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "author": "SIMP Team",
   "summary": "Manages SSSD",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/20_krb5_provider_spec.rb
+++ b/spec/acceptance/suites/default/20_krb5_provider_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper_acceptance'
+
+test_name 'sssd::provider::krb5 multiple servers'
+
+# Exercises the krb5 provider end to end: a single krb5_server/krb5_backup_server
+# value and an array must both render as a comma-separated list in the generated
+# drop-in (see #160).
+describe 'sssd::provider::krb5 with multiple servers' do
+  clients = hosts_with_role(hosts, 'client')
+
+  let(:hieradata) do
+    {
+      'simp_options::pki'         => true,
+      'simp_options::pki::source' => '/etc/pki/simp-testing/pki',
+      # auditd causes a lot of noise and reboots
+      'sssd::auditd'              => false,
+      'sssd::enable_files_domain' => true,
+      'sssd::domains'             => ['KRB5TEST'],
+    }
+  end
+
+  let(:manifest) do
+    <<~EOS
+      include 'sssd'
+
+      sssd::domain { 'KRB5TEST':
+        id_provider    => 'proxy',
+        proxy_lib_name => 'files',
+        auth_provider  => 'krb5',
+        min_id         => 1000,
+      }
+
+      sssd::provider::krb5 { 'KRB5TEST':
+        krb5_realm         => 'EXAMPLE.COM',
+        krb5_server        => ['kdc1.example.com', 'kdc2.example.com:88'],
+        krb5_backup_server => 'kdc3.example.com',
+      }
+    EOS
+  end
+
+  clients.each do |client|
+    context "on #{client}" do
+      it 'applies the manifest' do
+        set_hieradata_on(client, hieradata)
+        apply_manifest_on(client, manifest, catch_failures: true)
+      end
+
+      it 'is idempotent' do
+        apply_manifest_on(client, manifest, catch_changes: true)
+      end
+
+      it 'renders krb5_server and krb5_backup_server as comma-separated lists' do
+        content = on(client, 'cat /etc/sssd/conf.d/50_puppet_provider_KRB5TEST_krb5.conf').stdout
+        expect(content).to match(%r{^krb5_server = kdc1\.example\.com,kdc2\.example\.com:88$})
+        expect(content).to match(%r{^krb5_backup_server = kdc3\.example\.com$})
+      end
+    end
+  end
+end

--- a/spec/defines/provider/krb5_spec.rb
+++ b/spec/defines/provider/krb5_spec.rb
@@ -33,6 +33,26 @@ describe 'sssd::provider::krb5' do
         }
       end
 
+      context 'with multiple krb5 servers and a backup server' do
+        let(:params) do
+          {
+            krb5_server: ['kdc1.example.domain', 'kdc2.example.domain:88'],
+            krb5_backup_server: 'kdc3.example.domain',
+            krb5_realm: 'EXAMPLE.REALM',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to create_sssd__config__entry("puppet_provider_#{title}_krb5")
+            .with_content(%r{^krb5_server = kdc1\.example\.domain,kdc2\.example\.domain:88$})
+        }
+        it {
+          is_expected.to create_sssd__config__entry("puppet_provider_#{title}_krb5")
+            .with_content(%r{^krb5_backup_server = kdc3\.example\.domain$})
+        }
+      end
+
       context 'with optional parameters' do
         let(:params) do
           {

--- a/types/krb5server.pp
+++ b/types/krb5server.pp
@@ -1,0 +1,8 @@
+# Valid `krb5_server`/`krb5_backup_server` value: a single host (optionally
+# with a port), or a non-empty array of them. Rendered as a comma-separated
+# list in the SSSD configuration.
+type Sssd::Krb5Server = Variant[
+  Simplib::Host,
+  Simplib::Host::Port,
+  Array[Variant[Simplib::Host, Simplib::Host::Port], 1]
+]


### PR DESCRIPTION
Fixes #160
Rebuild of the stale #187 on current master (10.0.0).

- Add the Sssd::Krb5Server type: a single host (optionally host:port) or a non-empty array of them, rendered as a comma-separated list.
- sssd::provider::krb5: krb5_server now takes Sssd::Krb5Server (was a single Simplib::Host), and add a krb5_backup_server parameter.
- sssd::provider::ldap: retype krb5_server/krb5_backup_server to Sssd::Krb5Server (were Array[String[1],1]) to harmonize with the krb5 provider; a single value is now accepted too.
- Render server lists with [$x].flatten.join(',') rather than Array(), which would split a single string into characters.
- Add a multi-server + backup-server spec; bump to 10.1.0.